### PR TITLE
Convert visible state to use $state rune in essay routes

### DIFF
--- a/src/routes/essays/+page.svelte
+++ b/src/routes/essays/+page.svelte
@@ -6,7 +6,7 @@
 
 	let { data } = $props<{ data: PageData }>();
 
-	let visible = false;
+	let visible = $state(false);
 
 	const locale = $derived(getLocale());
 

--- a/src/routes/essays/[slug]/+page.svelte
+++ b/src/routes/essays/[slug]/+page.svelte
@@ -6,7 +6,7 @@
 
 	let { data } = $props<{ data: PageData }>();
 
-	let visible = false;
+	let visible = $state(false);
 
 	onMount(() => {
 		requestAnimationFrame(() => {


### PR DESCRIPTION
## Summary
Updated the `visible` variable declarations in essay route components to use Svelte 5's `$state` rune for proper reactivity.

## Changes
- `src/routes/essays/+page.svelte`: Changed `let visible = false;` to `let visible = $state(false);`
- `src/routes/essays/[slug]/+page.svelte`: Changed `let visible = false;` to `let visible = $state(false);`

## Details
These changes align with Svelte 5's reactivity model by explicitly marking the `visible` variable as reactive state using the `$state` rune. This ensures the variable is properly tracked for reactivity and follows current Svelte best practices.

https://claude.ai/code/session_01R2EW2uZAT4RbC21viMdcwq