### PR TITLE
Add VCF File Splitter tool for contact management

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,26 @@
+# CLAUDE.md
+
+## Project Overview
+
+Personal site for Hiro Kuwana — built with SvelteKit, Tailwind CSS v4, and DaisyUI v5. Deployed on Vercel.
+
+## Development Commands
+
+- `npm run dev` — Start dev server
+- `npm run build` — Production build (what Vercel runs)
+- `npm run check` — Run svelte-check for type errors
+- `npm run lint` — Prettier + ESLint
+
+## Pre-Publish Checklist
+
+- **Always check the Vercel build before publishing/merging.** Vercel deployments can fail for reasons not caught by local builds (node version differences, environment variables, edge function limits, etc.). Verify the preview deployment succeeds before merging a PR.
+- Run `npm run build` locally to catch build errors early.
+- Run `npm run check` to catch type errors (note: some pre-existing type errors exist on master).
+
+## Architecture Notes
+
+- **Routing**: File-based routing in `src/routes/`. Each page is a `+page.svelte` file.
+- **Data**: Shared constants (projects, tools, contact info) live in `src/data/constants.ts`.
+- **i18n**: Uses Paraglide (`$lib/paraglide/messages`) for translations.
+- **Tools pages**: Utility tools (ICS Validator, VCF Splitter) are standalone single-file pages under `src/routes/`. Follow the ICS Validator pattern for new tools.
+- **Styling**: Tailwind utility classes + DaisyUI components + scoped `<style>` blocks using `oklch()` color functions.

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
 				"@sveltejs/adapter-vercel": "^5.10.3",
 				"@tailwindcss/postcss": "^4.1.18",
 				"daisyui": "^5.5.14",
+				"jszip": "^3.10.1",
 				"mermaid": "^11.12.2"
 			},
 			"devDependencies": {
@@ -2734,7 +2735,6 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
 			"integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/cose-base": {
@@ -3970,6 +3970,12 @@
 				"node": ">= 4"
 			}
 		},
+		"node_modules/immediate": {
+			"version": "3.0.6",
+			"resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+			"integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+			"license": "MIT"
+		},
 		"node_modules/import-fresh": {
 			"version": "3.3.1",
 			"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -4006,6 +4012,12 @@
 			"engines": {
 				"node": ">=0.8.19"
 			}
+		},
+		"node_modules/inherits": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+			"license": "ISC"
 		},
 		"node_modules/internmap": {
 			"version": "2.0.3",
@@ -4056,6 +4068,12 @@
 			"dependencies": {
 				"@types/estree": "^1.0.6"
 			}
+		},
+		"node_modules/isarray": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+			"integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+			"license": "MIT"
 		},
 		"node_modules/isexe": {
 			"version": "2.0.0",
@@ -4139,6 +4157,18 @@
 			},
 			"engines": {
 				"node": ">=6"
+			}
+		},
+		"node_modules/jszip": {
+			"version": "3.10.1",
+			"resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+			"integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+			"license": "(MIT OR GPL-3.0-or-later)",
+			"dependencies": {
+				"lie": "~3.3.0",
+				"pako": "~1.0.2",
+				"readable-stream": "~2.3.6",
+				"setimmediate": "^1.0.5"
 			}
 		},
 		"node_modules/katex": {
@@ -4242,6 +4272,15 @@
 			},
 			"engines": {
 				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/lie": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+			"integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+			"license": "MIT",
+			"dependencies": {
+				"immediate": "~3.0.5"
 			}
 		},
 		"node_modules/lightningcss": {
@@ -4827,6 +4866,12 @@
 			"integrity": "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==",
 			"license": "MIT"
 		},
+		"node_modules/pako": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+			"integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+			"license": "(MIT AND Zlib)"
+		},
 		"node_modules/parent-module": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -5209,6 +5254,12 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/process-nextick-args": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+			"license": "MIT"
+		},
 		"node_modules/punycode": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -5217,6 +5268,21 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
+			}
+		},
+		"node_modules/readable-stream": {
+			"version": "2.3.8",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+			"integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+			"license": "MIT",
+			"dependencies": {
+				"core-util-is": "~1.0.0",
+				"inherits": "~2.0.3",
+				"isarray": "~1.0.0",
+				"process-nextick-args": "~2.0.0",
+				"safe-buffer": "~5.1.1",
+				"string_decoder": "~1.1.1",
+				"util-deprecate": "~1.0.1"
 			}
 		},
 		"node_modules/readdirp": {
@@ -5322,6 +5388,12 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/safe-buffer": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+			"license": "MIT"
+		},
 		"node_modules/safer-buffer": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -5344,6 +5416,12 @@
 			"version": "2.7.2",
 			"resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
 			"integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+			"license": "MIT"
+		},
+		"node_modules/setimmediate": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+			"integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
 			"license": "MIT"
 		},
 		"node_modules/shebang-command": {
@@ -5412,6 +5490,15 @@
 			},
 			"peerDependencies": {
 				"kysely": "*"
+			}
+		},
+		"node_modules/string_decoder": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+			"license": "MIT",
+			"dependencies": {
+				"safe-buffer": "~5.1.0"
 			}
 		},
 		"node_modules/string-width": {
@@ -5870,7 +5957,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
 			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/uuid": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
 		"@sveltejs/kit": "^2.50.1",
 		"@sveltejs/vite-plugin-svelte": "^5.1.1",
 		"@tailwindcss/vite": "^4.1.18",
+		"@types/node": "^25.5.2",
 		"eslint": "^9.39.2",
 		"eslint-config-prettier": "^10.1.8",
 		"eslint-plugin-svelte": "^3.14.0",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
 		"@sveltejs/adapter-vercel": "^5.10.3",
 		"@tailwindcss/postcss": "^4.1.18",
 		"daisyui": "^5.5.14",
+		"jszip": "^3.10.1",
 		"mermaid": "^11.12.2"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,16 +13,19 @@ importers:
         version: 2.9.1
       '@sveltejs/adapter-static':
         specifier: ^3.0.10
-        version: 3.0.10(@sveltejs/kit@2.50.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.49.1)(vite@6.4.1(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.89.2)(yaml@2.8.0)))(svelte@5.49.1)(typescript@5.9.3)(vite@6.4.1(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.89.2)(yaml@2.8.0)))
+        version: 3.0.10(@sveltejs/kit@2.50.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.49.1)(vite@6.4.1(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.89.2)(yaml@2.8.0)))(svelte@5.49.1)(typescript@5.9.3)(vite@6.4.1(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.89.2)(yaml@2.8.0)))
       '@sveltejs/adapter-vercel':
         specifier: ^5.10.3
-        version: 5.10.3(@sveltejs/kit@2.50.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.49.1)(vite@6.4.1(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.89.2)(yaml@2.8.0)))(svelte@5.49.1)(typescript@5.9.3)(vite@6.4.1(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.89.2)(yaml@2.8.0)))(rollup@4.57.0)
+        version: 5.10.3(@sveltejs/kit@2.50.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.49.1)(vite@6.4.1(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.89.2)(yaml@2.8.0)))(svelte@5.49.1)(typescript@5.9.3)(vite@6.4.1(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.89.2)(yaml@2.8.0)))(rollup@4.57.0)
       '@tailwindcss/postcss':
         specifier: ^4.1.18
         version: 4.1.18
       daisyui:
         specifier: ^5.5.14
         version: 5.5.14
+      jszip:
+        specifier: ^3.10.1
+        version: 3.10.1
       mermaid:
         specifier: ^11.12.2
         version: 11.12.2
@@ -47,13 +50,16 @@ importers:
         version: 3.1.4
       '@sveltejs/kit':
         specifier: ^2.50.1
-        version: 2.50.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.49.1)(vite@6.4.1(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.89.2)(yaml@2.8.0)))(svelte@5.49.1)(typescript@5.9.3)(vite@6.4.1(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.89.2)(yaml@2.8.0))
+        version: 2.50.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.49.1)(vite@6.4.1(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.89.2)(yaml@2.8.0)))(svelte@5.49.1)(typescript@5.9.3)(vite@6.4.1(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.89.2)(yaml@2.8.0))
       '@sveltejs/vite-plugin-svelte':
         specifier: ^5.1.1
-        version: 5.1.1(svelte@5.49.1)(vite@6.4.1(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.89.2)(yaml@2.8.0))
+        version: 5.1.1(svelte@5.49.1)(vite@6.4.1(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.89.2)(yaml@2.8.0))
       '@tailwindcss/vite':
         specifier: ^4.1.18
-        version: 4.1.18(vite@6.4.1(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.89.2)(yaml@2.8.0))
+        version: 4.1.18(vite@6.4.1(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.89.2)(yaml@2.8.0))
+      '@types/node':
+        specifier: ^25.5.2
+        version: 25.5.2
       eslint:
         specifier: ^9.39.2
         version: 9.39.2(jiti@2.6.1)
@@ -95,7 +101,7 @@ importers:
         version: 8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       vite:
         specifier: ^6.4.1
-        version: 6.4.1(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.89.2)(yaml@2.8.0)
+        version: 6.4.1(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.89.2)(yaml@2.8.0)
 
 packages:
 
@@ -442,36 +448,42 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm-musl@2.5.6':
     resolution: {integrity: sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-arm64-glibc@2.5.6':
     resolution: {integrity: sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-musl@2.5.6':
     resolution: {integrity: sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-x64-glibc@2.5.6':
     resolution: {integrity: sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-x64-musl@2.5.6':
     resolution: {integrity: sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-win32-arm64@2.5.6':
     resolution: {integrity: sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==}
@@ -545,66 +557,79 @@ packages:
     resolution: {integrity: sha512-eyrr5W08Ms9uM0mLcKfM/Uzx7hjhz2bcjv8P2uynfj0yU8GGPdz8iYrBPhiLOZqahoAMB8ZiolRZPbbU2MAi6Q==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.57.0':
     resolution: {integrity: sha512-Xds90ITXJCNyX9pDhqf85MKWUI4lqjiPAipJ8OLp8xqI2Ehk+TCVhF9rvOoN8xTbcafow3QOThkNnrM33uCFQA==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.57.0':
     resolution: {integrity: sha512-Xws2KA4CLvZmXjy46SQaXSejuKPhwVdaNinldoYfqruZBaJHqVo6hnRa8SDo9z7PBW5x84SH64+izmldCgbezw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.57.0':
     resolution: {integrity: sha512-hrKXKbX5FdaRJj7lTMusmvKbhMJSGWJ+w++4KmjiDhpTgNlhYobMvKfDoIWecy4O60K6yA4SnztGuNTQF+Lplw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.57.0':
     resolution: {integrity: sha512-6A+nccfSDGKsPm00d3xKcrsBcbqzCTAukjwWK6rbuAnB2bHaL3r9720HBVZ/no7+FhZLz/U3GwwZZEh6tOSI8Q==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.57.0':
     resolution: {integrity: sha512-4P1VyYUe6XAJtQH1Hh99THxr0GKMMwIXsRNOceLrJnaHTDgk1FTcTimDgneRJPvB3LqDQxUmroBclQ1S0cIJwQ==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.57.0':
     resolution: {integrity: sha512-8Vv6pLuIZCMcgXre6c3nOPhE0gjz1+nZP6T+hwWjr7sVH8k0jRkH+XnfjjOTglyMBdSKBPPz54/y1gToSKwrSQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.57.0':
     resolution: {integrity: sha512-r1te1M0Sm2TBVD/RxBPC6RZVwNqUTwJTA7w+C/IW5v9Ssu6xmxWEi+iJQlpBhtUiT1raJ5b48pI8tBvEjEFnFA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.57.0':
     resolution: {integrity: sha512-say0uMU/RaPm3CDQLxUUTF2oNWL8ysvHkAjcCzV2znxBr23kFfaxocS9qJm+NdkRhF8wtdEEAJuYcLPhSPbjuQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.57.0':
     resolution: {integrity: sha512-/MU7/HizQGsnBREtRpcSbSV1zfkoxSTR7wLsRmBPQ8FwUj5sykrP1MyJTvsxP5KBq9SyE6kH8UQQQwa0ASeoQQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.57.0':
     resolution: {integrity: sha512-Q9eh+gUGILIHEaJf66aF6a414jQbDnn29zeu0eX3dHMuysnhTvsUvZTCAyZ6tJhUjnvzBKE4FtuaYxutxRZpOg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.57.0':
     resolution: {integrity: sha512-OR5p5yG5OKSxHReWmwvM0P+VTPMwoBS45PXTMYaskKQqybkS3Kmugq1W+YbNWArF8/s7jQScgzXUhArzEQ7x0A==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.57.0':
     resolution: {integrity: sha512-XeatKzo4lHDsVEbm1XDHZlhYZZSQYym6dg2X/Ko0kSFgio+KXLsxwJQprnR48GvdIKDOpqWqssC3iBCjoMcMpw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.57.0':
     resolution: {integrity: sha512-Lu71y78F5qOfYmubYLHPcJm74GZLU6UJ4THkf/a1K7Tz2ycwC2VUbsqbJAXaR6Bx70SRdlVrt2+n5l7F0agTUw==}
@@ -730,24 +755,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.18':
     resolution: {integrity: sha512-1px92582HkPQlaaCkdRcio71p8bc8i/ap5807tPRDK/uw953cauQBT8c5tVGkOwrHMfc2Yh6UuxaH4vtTjGvHg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.18':
     resolution: {integrity: sha512-v3gyT0ivkfBLoZGF9LyHmts0Isc8jHZyVcbzio6Wpzifg/+5ZJpDiRiUhDLkcr7f/r38SWNe7ucxmGW3j3Kb/g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.18':
     resolution: {integrity: sha512-bhJ2y2OQNlcRwwgOAGMY0xTFStt4/wyU6pvI6LSuZpRgKQwxTec0/3Scu91O8ir7qCR3AuepQKLU/kX99FouqQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.18':
     resolution: {integrity: sha512-LffYTvPjODiP6PT16oNeUQJzNVyJl1cjIebq/rWWBF+3eDst5JGEFSc5cWxyRCJ0Mxl+KyIkqRxk1XPEs9x8TA==}
@@ -892,6 +921,9 @@ packages:
 
   '@types/mdast@4.0.4':
     resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
+
+  '@types/node@25.5.2':
+    resolution: {integrity: sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg==}
 
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
@@ -1510,6 +1542,9 @@ packages:
     resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
 
+  immediate@3.0.6:
+    resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
+
   immutable@5.1.4:
     resolution: {integrity: sha512-p6u1bG3YSnINT5RQmx/yRZBpenIl30kVxkTLDyHLIMk0gict704Q9n+thfDI7lTRm9vXdDYutVzXhzcThxTnXA==}
 
@@ -1520,6 +1555,9 @@ packages:
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
   internmap@1.0.1:
     resolution: {integrity: sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==}
@@ -1542,6 +1580,9 @@ packages:
 
   is-reference@3.0.3:
     resolution: {integrity: sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==}
+
+  isarray@1.0.0:
+    resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -1573,6 +1614,9 @@ packages:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
     hasBin: true
+
+  jszip@3.10.1:
+    resolution: {integrity: sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==}
 
   katex@0.16.28:
     resolution: {integrity: sha512-YHzO7721WbmAL6Ov1uzN/l5mY5WWWhJBSW+jq4tkfZfsxmo1hu6frS0EOswvjBUnWE6NtjEs48SFn5CQESRLZg==}
@@ -1609,6 +1653,9 @@ packages:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
 
+  lie@3.3.0:
+    resolution: {integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==}
+
   lightningcss-android-arm64@1.30.2:
     resolution: {integrity: sha512-BH9sEdOCahSgmkVhBLeU7Hc9DWeZ1Eb6wNS6Da8igvUwAe0sqROHddIlvU06q3WyXVEOYDZ6ykBZQnjTbmo4+A==}
     engines: {node: '>= 12.0.0'}
@@ -1644,24 +1691,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.2:
     resolution: {integrity: sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.2:
     resolution: {integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.2:
     resolution: {integrity: sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.2:
     resolution: {integrity: sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==}
@@ -1793,6 +1844,9 @@ packages:
 
   package-manager-detector@1.6.0:
     resolution: {integrity: sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==}
+
+  pako@1.0.11:
+    resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
 
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
@@ -1947,9 +2001,15 @@ packages:
     resolution: {integrity: sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==}
     engines: {node: '>=6'}
 
+  process-nextick-args@2.0.1:
+    resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  readable-stream@2.3.8:
+    resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
 
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
@@ -1981,6 +2041,9 @@ packages:
     resolution: {integrity: sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==}
     engines: {node: '>=6'}
 
+  safe-buffer@5.1.2:
+    resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
+
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
@@ -1996,6 +2059,9 @@ packages:
 
   set-cookie-parser@2.7.2:
     resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
+
+  setimmediate@1.0.5:
+    resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -2029,6 +2095,9 @@ packages:
   string-width@5.1.2:
     resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
     engines: {node: '>=12'}
+
+  string_decoder@1.1.1:
+    resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
 
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
@@ -2124,6 +2193,9 @@ packages:
 
   ufo@1.6.3:
     resolution: {integrity: sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==}
+
+  undici-types@7.18.2:
+    resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
   unist-util-is@4.1.0:
     resolution: {integrity: sha512-ZOQSsnce92GrxSqlnEEseX0gi7GH9zTJZ0p9dtu87WRb/37mMPO2Ilx1s/t9vBHrFhbgweUwb+t7cIn5dxPhZg==}
@@ -2723,13 +2795,13 @@ snapshots:
     dependencies:
       acorn: 8.15.0
 
-  '@sveltejs/adapter-static@3.0.10(@sveltejs/kit@2.50.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.49.1)(vite@6.4.1(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.89.2)(yaml@2.8.0)))(svelte@5.49.1)(typescript@5.9.3)(vite@6.4.1(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.89.2)(yaml@2.8.0)))':
+  '@sveltejs/adapter-static@3.0.10(@sveltejs/kit@2.50.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.49.1)(vite@6.4.1(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.89.2)(yaml@2.8.0)))(svelte@5.49.1)(typescript@5.9.3)(vite@6.4.1(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.89.2)(yaml@2.8.0)))':
     dependencies:
-      '@sveltejs/kit': 2.50.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.49.1)(vite@6.4.1(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.89.2)(yaml@2.8.0)))(svelte@5.49.1)(typescript@5.9.3)(vite@6.4.1(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.89.2)(yaml@2.8.0))
+      '@sveltejs/kit': 2.50.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.49.1)(vite@6.4.1(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.89.2)(yaml@2.8.0)))(svelte@5.49.1)(typescript@5.9.3)(vite@6.4.1(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.89.2)(yaml@2.8.0))
 
-  '@sveltejs/adapter-vercel@5.10.3(@sveltejs/kit@2.50.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.49.1)(vite@6.4.1(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.89.2)(yaml@2.8.0)))(svelte@5.49.1)(typescript@5.9.3)(vite@6.4.1(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.89.2)(yaml@2.8.0)))(rollup@4.57.0)':
+  '@sveltejs/adapter-vercel@5.10.3(@sveltejs/kit@2.50.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.49.1)(vite@6.4.1(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.89.2)(yaml@2.8.0)))(svelte@5.49.1)(typescript@5.9.3)(vite@6.4.1(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.89.2)(yaml@2.8.0)))(rollup@4.57.0)':
     dependencies:
-      '@sveltejs/kit': 2.50.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.49.1)(vite@6.4.1(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.89.2)(yaml@2.8.0)))(svelte@5.49.1)(typescript@5.9.3)(vite@6.4.1(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.89.2)(yaml@2.8.0))
+      '@sveltejs/kit': 2.50.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.49.1)(vite@6.4.1(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.89.2)(yaml@2.8.0)))(svelte@5.49.1)(typescript@5.9.3)(vite@6.4.1(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.89.2)(yaml@2.8.0))
       '@vercel/nft': 0.30.4(rollup@4.57.0)
       esbuild: 0.25.12
     transitivePeerDependencies:
@@ -2737,11 +2809,11 @@ snapshots:
       - rollup
       - supports-color
 
-  '@sveltejs/kit@2.50.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.49.1)(vite@6.4.1(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.89.2)(yaml@2.8.0)))(svelte@5.49.1)(typescript@5.9.3)(vite@6.4.1(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.89.2)(yaml@2.8.0))':
+  '@sveltejs/kit@2.50.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.49.1)(vite@6.4.1(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.89.2)(yaml@2.8.0)))(svelte@5.49.1)(typescript@5.9.3)(vite@6.4.1(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.89.2)(yaml@2.8.0))':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@sveltejs/acorn-typescript': 1.0.8(acorn@8.15.0)
-      '@sveltejs/vite-plugin-svelte': 5.1.1(svelte@5.49.1)(vite@6.4.1(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.89.2)(yaml@2.8.0))
+      '@sveltejs/vite-plugin-svelte': 5.1.1(svelte@5.49.1)(vite@6.4.1(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.89.2)(yaml@2.8.0))
       '@types/cookie': 0.6.0
       acorn: 8.15.0
       cookie: 0.6.0
@@ -2754,29 +2826,29 @@ snapshots:
       set-cookie-parser: 2.7.2
       sirv: 3.0.2
       svelte: 5.49.1
-      vite: 6.4.1(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.89.2)(yaml@2.8.0)
+      vite: 6.4.1(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.89.2)(yaml@2.8.0)
     optionalDependencies:
       typescript: 5.9.3
 
-  '@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.49.1)(vite@6.4.1(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.89.2)(yaml@2.8.0)))(svelte@5.49.1)(vite@6.4.1(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.89.2)(yaml@2.8.0))':
+  '@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.49.1)(vite@6.4.1(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.89.2)(yaml@2.8.0)))(svelte@5.49.1)(vite@6.4.1(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.89.2)(yaml@2.8.0))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 5.1.1(svelte@5.49.1)(vite@6.4.1(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.89.2)(yaml@2.8.0))
+      '@sveltejs/vite-plugin-svelte': 5.1.1(svelte@5.49.1)(vite@6.4.1(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.89.2)(yaml@2.8.0))
       debug: 4.4.3
       svelte: 5.49.1
-      vite: 6.4.1(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.89.2)(yaml@2.8.0)
+      vite: 6.4.1(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.89.2)(yaml@2.8.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.49.1)(vite@6.4.1(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.89.2)(yaml@2.8.0))':
+  '@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.49.1)(vite@6.4.1(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.89.2)(yaml@2.8.0))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.49.1)(vite@6.4.1(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.89.2)(yaml@2.8.0)))(svelte@5.49.1)(vite@6.4.1(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.89.2)(yaml@2.8.0))
+      '@sveltejs/vite-plugin-svelte-inspector': 4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.49.1)(vite@6.4.1(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.89.2)(yaml@2.8.0)))(svelte@5.49.1)(vite@6.4.1(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.89.2)(yaml@2.8.0))
       debug: 4.4.3
       deepmerge: 4.3.1
       kleur: 4.1.5
       magic-string: 0.30.21
       svelte: 5.49.1
-      vite: 6.4.1(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.89.2)(yaml@2.8.0)
-      vitefu: 1.1.1(vite@6.4.1(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.89.2)(yaml@2.8.0))
+      vite: 6.4.1(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.89.2)(yaml@2.8.0)
+      vitefu: 1.1.1(vite@6.4.1(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.89.2)(yaml@2.8.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -2849,12 +2921,12 @@ snapshots:
       postcss: 8.5.6
       tailwindcss: 4.1.18
 
-  '@tailwindcss/vite@4.1.18(vite@6.4.1(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.89.2)(yaml@2.8.0))':
+  '@tailwindcss/vite@4.1.18(vite@6.4.1(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.89.2)(yaml@2.8.0))':
     dependencies:
       '@tailwindcss/node': 4.1.18
       '@tailwindcss/oxide': 4.1.18
       tailwindcss: 4.1.18
-      vite: 6.4.1(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.89.2)(yaml@2.8.0)
+      vite: 6.4.1(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.89.2)(yaml@2.8.0)
 
   '@types/cookie@0.6.0': {}
 
@@ -2984,6 +3056,10 @@ snapshots:
   '@types/mdast@4.0.4':
     dependencies:
       '@types/unist': 2.0.11
+
+  '@types/node@25.5.2':
+    dependencies:
+      undici-types: 7.18.2
 
   '@types/trusted-types@2.0.7':
     optional: true
@@ -3661,6 +3737,8 @@ snapshots:
 
   ignore@7.0.5: {}
 
+  immediate@3.0.6: {}
+
   immutable@5.1.4:
     optional: true
 
@@ -3670,6 +3748,8 @@ snapshots:
       resolve-from: 4.0.0
 
   imurmurhash@0.1.4: {}
+
+  inherits@2.0.4: {}
 
   internmap@1.0.1: {}
 
@@ -3686,6 +3766,8 @@ snapshots:
   is-reference@3.0.3:
     dependencies:
       '@types/estree': 1.0.8
+
+  isarray@1.0.0: {}
 
   isexe@2.0.0: {}
 
@@ -3710,6 +3792,13 @@ snapshots:
   json-stable-stringify-without-jsonify@1.0.1: {}
 
   json5@2.2.3: {}
+
+  jszip@3.10.1:
+    dependencies:
+      lie: 3.3.0
+      pako: 1.0.11
+      readable-stream: 2.3.8
+      setimmediate: 1.0.5
 
   katex@0.16.28:
     dependencies:
@@ -3743,6 +3832,10 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
       type-check: 0.4.0
+
+  lie@3.3.0:
+    dependencies:
+      immediate: 3.0.6
 
   lightningcss-android-arm64@1.30.2:
     optional: true
@@ -3913,6 +4006,8 @@ snapshots:
 
   package-manager-detector@1.6.0: {}
 
+  pako@1.0.11: {}
+
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
@@ -3992,7 +4087,19 @@ snapshots:
 
   prismjs@1.30.0: {}
 
+  process-nextick-args@2.0.1: {}
+
   punycode@2.3.1: {}
+
+  readable-stream@2.3.8:
+    dependencies:
+      core-util-is: 1.0.3
+      inherits: 2.0.4
+      isarray: 1.0.0
+      process-nextick-args: 2.0.1
+      safe-buffer: 5.1.2
+      string_decoder: 1.1.1
+      util-deprecate: 1.0.2
 
   readdirp@4.1.2: {}
 
@@ -4046,6 +4153,8 @@ snapshots:
     dependencies:
       mri: 1.2.0
 
+  safe-buffer@5.1.2: {}
+
   safer-buffer@2.1.2: {}
 
   sass@1.89.2:
@@ -4060,6 +4169,8 @@ snapshots:
   semver@7.7.3: {}
 
   set-cookie-parser@2.7.2: {}
+
+  setimmediate@1.0.5: {}
 
   shebang-command@2.0.0:
     dependencies:
@@ -4093,6 +4204,10 @@ snapshots:
       eastasianwidth: 0.2.0
       emoji-regex: 9.2.2
       strip-ansi: 7.1.2
+
+  string_decoder@1.1.1:
+    dependencies:
+      safe-buffer: 5.1.2
 
   strip-ansi@6.0.1:
     dependencies:
@@ -4199,6 +4314,8 @@ snapshots:
 
   ufo@1.6.3: {}
 
+  undici-types@7.18.2: {}
+
   unist-util-is@4.1.0: {}
 
   unist-util-stringify-position@2.0.3:
@@ -4242,7 +4359,7 @@ snapshots:
       '@types/unist': 2.0.11
       unist-util-stringify-position: 2.0.3
 
-  vite@6.4.1(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.89.2)(yaml@2.8.0):
+  vite@6.4.1(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.89.2)(yaml@2.8.0):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.3)
@@ -4251,15 +4368,16 @@ snapshots:
       rollup: 4.57.0
       tinyglobby: 0.2.15
     optionalDependencies:
+      '@types/node': 25.5.2
       fsevents: 2.3.3
       jiti: 2.6.1
       lightningcss: 1.30.2
       sass: 1.89.2
       yaml: 2.8.0
 
-  vitefu@1.1.1(vite@6.4.1(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.89.2)(yaml@2.8.0)):
+  vitefu@1.1.1(vite@6.4.1(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.89.2)(yaml@2.8.0)):
     optionalDependencies:
-      vite: 6.4.1(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.89.2)(yaml@2.8.0)
+      vite: 6.4.1(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.89.2)(yaml@2.8.0)
 
   vscode-jsonrpc@8.2.0: {}
 

--- a/src/data/constants.ts
+++ b/src/data/constants.ts
@@ -55,7 +55,18 @@ export const PERSONAL = {
 } as const;
 
 // Projects
-export const PROJECTS = [
+interface Project {
+	name: string;
+	tagline: string;
+	description: string;
+	link?: string;
+	github?: string;
+	logo: string;
+	status: 'current' | 'active' | 'sunset';
+	color: string;
+}
+
+export const PROJECTS: Project[] = [
 	{
 		name: 'Kaiwa',
 		tagline: 'Language Learning, Reimagined',
@@ -105,7 +116,7 @@ export const PROJECTS = [
 		status: 'sunset',
 		color: '#6b7280',
 	},
-] as const;
+];
 
 // Tools & Experiments - One-off projects and utilities
 export const TOOLS = [

--- a/src/data/constants.ts
+++ b/src/data/constants.ts
@@ -117,6 +117,14 @@ export const TOOLS = [
 		icon: 'calendar',
 		color: '#6366f1',
 	},
+	{
+		name: 'VCF File Splitter',
+		description:
+			'Upload a .vcf file with multiple contacts and split it into individual vCard files. Download as a ZIP for easy iPhone/Android import.',
+		href: '/vcf-splitter',
+		icon: 'contacts',
+		color: '#10b981',
+	},
 ] as const;
 
 // Expertise Areas

--- a/src/lib/components/LanguageToggle.svelte
+++ b/src/lib/components/LanguageToggle.svelte
@@ -26,6 +26,7 @@
 		class:active={currentLang === 'en'}
 		aria-label="English"
 		aria-current={currentLang === 'en' ? 'true' : undefined}
+		data-sveltekit-reload
 	>
 		<FlagIcon countryCode="us" size="h-5 w-5" />
 	</a>
@@ -37,6 +38,7 @@
 		class:active={currentLang === 'ja'}
 		aria-label="日本語"
 		aria-current={currentLang === 'ja' ? 'true' : undefined}
+		data-sveltekit-reload
 	>
 		<FlagIcon countryCode="jp" size="h-5 w-5" />
 	</a>

--- a/src/lib/components/header.svelte
+++ b/src/lib/components/header.svelte
@@ -10,7 +10,7 @@
 <header class="header">
 	<div class="header-inner">
 		<nav class="nav">
-			<a href={localizeHref('/')} class="nav-link text-secondary hover:text-primary" class:active={$page.url.pathname === '/' || $page.url.pathname === '/ja'}>
+			<a href={localizeHref('/')} class="nav-link text-secondary hover:text-primary" class:active={$page.url.pathname === '/' || String($page.url.pathname) === '/ja'}>
 				{m.nav_home()}
 			</a>
 			<span class="nav-divider"></span>

--- a/src/routes/essays/[slug]/+page.svelte
+++ b/src/routes/essays/[slug]/+page.svelte
@@ -72,7 +72,7 @@
 	</header>
 
 	<div class="essay-content">
-		<svelte:component this={data.content} />
+		<data.content />
 	</div>
 
 	<footer class="essay-footer">

--- a/src/routes/ics-validator/+page.svelte
+++ b/src/routes/ics-validator/+page.svelte
@@ -972,7 +972,7 @@ END:VCALENDAR`;
 					<div class="card-body">
 						<div class="flex justify-between items-start">
 							<h3 class="card-title text-primary">{selectedEvent.summary}</h3>
-							<button class="btn btn-sm btn-ghost btn-circle" onclick={() => selectedEvent = null}>
+							<button class="btn btn-sm btn-ghost btn-circle" onclick={() => selectedEvent = null} aria-label="Close event details">
 								<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" /></svg>
 							</button>
 						</div>
@@ -1364,6 +1364,7 @@ END:VCALENDAR`;
 		text-overflow: ellipsis;
 		display: -webkit-box;
 		-webkit-line-clamp: 2;
+		line-clamp: 2;
 		-webkit-box-orient: vertical;
 	}
 

--- a/src/routes/vcf-splitter/+page.svelte
+++ b/src/routes/vcf-splitter/+page.svelte
@@ -3,9 +3,12 @@
 	import JSZip from 'jszip';
 
 	let visible = $state(false);
+	let vcfInput = $state('');
 	let isDragging = $state(false);
 	let searchQuery = $state('');
 	let selectAll = $state(true);
+	let hasSplit = $state(false);
+	let activeTab = $state<'editor' | 'contacts'>('editor');
 
 	interface Contact {
 		raw: string;
@@ -17,7 +20,6 @@
 	}
 
 	let contacts: Contact[] = $state([]);
-	let fileName = $state('');
 
 	const SAMPLE_VCF = `BEGIN:VCARD
 VERSION:3.0
@@ -68,6 +70,7 @@ END:VCARD`;
 		requestAnimationFrame(() => {
 			visible = true;
 		});
+		vcfInput = SAMPLE_VCF;
 	});
 
 	function parseVcf(text: string): Contact[] {
@@ -93,7 +96,6 @@ END:VCARD`;
 				if (upper.startsWith('FN:') || upper.startsWith('FN;')) {
 					fn = extractValue(line);
 				} else if (!fn && (upper.startsWith('N:') || upper.startsWith('N;'))) {
-					// Fallback: construct from N field (Last;First;Middle;Prefix;Suffix)
 					const parts = extractValue(line).split(';');
 					const first = parts[1] || '';
 					const last = parts[0] || '';
@@ -121,22 +123,29 @@ END:VCARD`;
 	}
 
 	function extractValue(line: string): string {
-		// Handle property parameters: PROP;PARAM=VAL:actual value
 		const colonIdx = line.indexOf(':');
 		if (colonIdx === -1) return '';
 		return line.substring(colonIdx + 1).trim();
+	}
+
+	function splitContacts() {
+		contacts = parseVcf(vcfInput);
+		selectAll = true;
+		hasSplit = true;
+		if (contacts.length > 0) {
+			activeTab = 'contacts';
+		}
 	}
 
 	function handleFileUpload(event: Event) {
 		const input = event.target as HTMLInputElement;
 		const file = input.files?.[0];
 		if (!file) return;
-		fileName = file.name;
 		const reader = new FileReader();
 		reader.onload = (e) => {
-			const text = (e.target?.result as string) || '';
-			contacts = parseVcf(text);
-			selectAll = true;
+			vcfInput = (e.target?.result as string) || '';
+			hasSplit = false;
+			contacts = [];
 		};
 		reader.readAsText(file);
 	}
@@ -146,12 +155,11 @@ END:VCARD`;
 		isDragging = false;
 		const file = event.dataTransfer?.files?.[0];
 		if (!file) return;
-		fileName = file.name;
 		const reader = new FileReader();
 		reader.onload = (e) => {
-			const text = (e.target?.result as string) || '';
-			contacts = parseVcf(text);
-			selectAll = true;
+			vcfInput = (e.target?.result as string) || '';
+			hasSplit = false;
+			contacts = [];
 		};
 		reader.readAsText(file);
 	}
@@ -166,16 +174,19 @@ END:VCARD`;
 	}
 
 	function loadSample() {
-		contacts = parseVcf(SAMPLE_VCF);
-		fileName = 'sample-contacts.vcf';
-		selectAll = true;
+		vcfInput = SAMPLE_VCF;
+		hasSplit = false;
+		contacts = [];
+		activeTab = 'editor';
 	}
 
-	function clearAll() {
+	function clearInput() {
+		vcfInput = '';
+		hasSplit = false;
 		contacts = [];
-		fileName = '';
 		searchQuery = '';
 		selectAll = true;
+		activeTab = 'editor';
 	}
 
 	function sanitizeFilename(name: string): string {
@@ -215,8 +226,7 @@ END:VCARD`;
 		const url = URL.createObjectURL(blob);
 		const a = document.createElement('a');
 		a.href = url;
-		const baseName = fileName ? fileName.replace(/\.vcf$/i, '') : 'contacts';
-		a.download = `${baseName}_split.zip`;
+		a.download = 'contacts_split.zip';
 		document.body.appendChild(a);
 		a.click();
 		document.body.removeChild(a);
@@ -243,286 +253,391 @@ END:VCARD`;
 	});
 
 	let selectedCount = $derived(contacts.filter((c) => c.selected).length);
+
+	let contactStats = $derived.by(() => {
+		if (contacts.length === 0) return null;
+		const withEmail = contacts.filter((c) => c.email).length;
+		const withPhone = contacts.filter((c) => c.tel).length;
+		const withOrg = contacts.filter((c) => c.org).length;
+		return { withEmail, withPhone, withOrg };
+	});
 </script>
 
 <svelte:head>
-	<title>VCF Splitter - Split Contacts into Individual Files - Hiro Kuwana</title>
+	<title>VCF Splitter & Contact Exporter - Hiro Kuwana</title>
 	<meta
 		name="description"
 		content="Split a single VCF file containing multiple contacts into individual vCard files. Perfect for importing contacts to iPhone, Android, or any device. Free, private, runs entirely in your browser."
 	/>
-	<meta name="keywords" content="vcf splitter, vcard splitter, split contacts, vcf to individual files, iphone contacts import, vcard converter" />
-	<meta property="og:title" content="VCF Splitter - Split Contacts into Individual Files" />
-	<meta property="og:description" content="Split a multi-contact VCF file into individual vCard files for easy import to iPhone, Android, or any device." />
-	<meta property="og:type" content="website" />
 </svelte:head>
 
 <article class="vcf-page" class:visible>
 	<header class="page-header">
 		<h1 class="page-title text-primary">VCF File Splitter</h1>
 		<p class="page-subtitle text-secondary">
-			Upload a .vcf file with multiple contacts and split it into individual vCard files.
-			Download them all as a ZIP or one at a time. Everything runs in your browser — no data leaves your device.
+			Paste or upload a .vcf file with multiple contacts. Split them into individual vCard files
+			and download as a ZIP for easy iPhone, Android, or iCloud import.
 		</p>
 	</header>
 
 	<div class="vcf-container">
-		<!-- Upload section -->
-		<div
-			class="upload-section"
-			class:dragging={isDragging}
-			ondrop={handleDrop}
-			ondragover={handleDragOver}
-			ondragleave={handleDragLeave}
-			role="region"
-			aria-label="VCF file upload"
-		>
-			{#if contacts.length === 0}
-				<div class="upload-zone" class:dragging={isDragging}>
+		<!-- Tab navigation -->
+		<div role="tablist" class="tabs tabs-bordered tabs-lg">
+			<button
+				role="tab"
+				class="tab"
+				class:tab-active={activeTab === 'editor'}
+				onclick={() => activeTab = 'editor'}
+			>
+				<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="mr-2">
+					<path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+					<polyline points="14 2 14 8 20 8" />
+					<line x1="16" y1="13" x2="8" y2="13" />
+					<line x1="16" y1="17" x2="8" y2="17" />
+				</svg>
+				Editor
+			</button>
+			<button
+				role="tab"
+				class="tab"
+				class:tab-active={activeTab === 'contacts'}
+				onclick={() => activeTab = 'contacts'}
+				disabled={contacts.length === 0}
+			>
+				<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="mr-2">
+					<path d="M16 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" />
+					<circle cx="8.5" cy="7" r="4" />
+					<line x1="20" y1="8" x2="20" y2="14" />
+					<line x1="23" y1="11" x2="17" y2="11" />
+				</svg>
+				Contacts
+				{#if contacts.length > 0}
+					<span class="badge badge-sm badge-primary ml-2">{contacts.length}</span>
+				{/if}
+			</button>
+		</div>
+
+		<!-- Editor tab -->
+		{#if activeTab === 'editor'}
+			<div
+				class="input-section"
+				class:dragging={isDragging}
+				ondrop={handleDrop}
+				ondragover={handleDragOver}
+				ondragleave={handleDragLeave}
+				role="region"
+				aria-label="VCF file input"
+			>
+				<div class="input-actions">
+					<label class="btn btn-sm btn-outline btn-secondary upload-btn">
+						<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+							<path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+							<polyline points="17 8 12 3 7 8" />
+							<line x1="12" y1="3" x2="12" y2="15" />
+						</svg>
+						Upload .vcf
+						<input
+							type="file"
+							accept=".vcf,.vcard"
+							onchange={handleFileUpload}
+							class="hidden"
+						/>
+					</label>
+					<button class="btn btn-sm btn-outline btn-secondary" onclick={loadSample}>
+						Load Sample
+					</button>
+					<button class="btn btn-sm btn-ghost text-secondary" onclick={clearInput}>Clear</button>
+				</div>
+
+				<div class="textarea-wrapper" class:dragging={isDragging}>
 					{#if isDragging}
 						<div class="drop-overlay">
-							<svg width="40" height="40" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+							<svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
 								<path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
 								<polyline points="17 8 12 3 7 8" />
 								<line x1="12" y1="3" x2="12" y2="15" />
 							</svg>
 							<span>Drop your .vcf file here</span>
 						</div>
-					{:else}
-						<div class="upload-prompt">
-							<svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" class="upload-icon">
-								<path d="M16 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" />
-								<circle cx="8.5" cy="7" r="4" />
-								<line x1="20" y1="8" x2="20" y2="14" />
-								<line x1="23" y1="11" x2="17" y2="11" />
-							</svg>
-							<p class="upload-text">Drag & drop your .vcf file here</p>
-							<p class="upload-hint">or use the buttons below</p>
-							<div class="upload-actions">
-								<label class="btn btn-primary upload-btn">
-									<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-										<path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
-										<polyline points="17 8 12 3 7 8" />
-										<line x1="12" y1="3" x2="12" y2="15" />
-									</svg>
-									Upload .vcf File
-									<input
-										type="file"
-										accept=".vcf,.vcard"
-										onchange={handleFileUpload}
-										class="hidden"
-									/>
-								</label>
-								<button class="btn btn-outline btn-secondary" onclick={loadSample}>
-									Load Sample
-								</button>
-							</div>
-						</div>
 					{/if}
+					<textarea
+						class="textarea textarea-bordered vcf-textarea"
+						placeholder="Paste your .vcf file content here, or drag & drop a file..."
+						bind:value={vcfInput}
+						rows="18"
+					></textarea>
 				</div>
-			{:else}
-				<!-- Results section -->
-				<div class="results-section">
-					<div class="results-header">
-						<div class="results-info">
-							<h2 class="results-title">
-								{contacts.length} Contact{contacts.length !== 1 ? 's' : ''} Found
-							</h2>
-							{#if fileName}
-								<span class="file-badge badge badge-outline badge-sm gap-1">
-									<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-										<path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
-										<polyline points="14 2 14 8 20 8" />
-									</svg>
-									{fileName}
-								</span>
-							{/if}
-						</div>
-						<div class="results-actions">
-							<label class="btn btn-sm btn-outline btn-secondary upload-btn">
-								<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-									<path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
-									<polyline points="17 8 12 3 7 8" />
-									<line x1="12" y1="3" x2="12" y2="15" />
-								</svg>
-								New File
-								<input
-									type="file"
-									accept=".vcf,.vcard"
-									onchange={handleFileUpload}
-									class="hidden"
-								/>
-							</label>
-							<button class="btn btn-sm btn-ghost text-secondary" onclick={clearAll}>Clear</button>
-						</div>
-					</div>
+			</div>
+		{/if}
 
-					<!-- Search and actions bar -->
-					<div class="toolbar">
-						<div class="search-box">
-							<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="search-icon">
-								<circle cx="11" cy="11" r="8" />
-								<line x1="21" y1="21" x2="16.65" y2="16.65" />
-							</svg>
-							<input
-								type="text"
-								class="input input-bordered input-sm search-input"
-								placeholder="Search contacts..."
-								bind:value={searchQuery}
-							/>
-						</div>
-						<div class="bulk-actions">
-							<button
-								class="btn btn-sm btn-primary gap-2"
-								onclick={downloadAllZip}
-								disabled={selectedCount === 0}
-							>
-								<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-									<path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
-									<polyline points="7 10 12 15 17 10" />
-									<line x1="12" y1="15" x2="12" y2="3" />
-								</svg>
-								Download ZIP ({selectedCount})
-							</button>
-						</div>
-					</div>
+		<!-- Contacts tab -->
+		{#if activeTab === 'contacts' && contacts.length > 0}
+			<!-- Stats bar -->
+			<div class="stats-bar">
+				<div class="stats-info">
+					<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+						<path d="M16 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" />
+						<circle cx="8.5" cy="7" r="4" />
+						<line x1="20" y1="8" x2="20" y2="14" />
+						<line x1="23" y1="11" x2="17" y2="11" />
+					</svg>
+					<span class="stats-label">{contacts.length} contact{contacts.length !== 1 ? 's' : ''} found</span>
+				</div>
 
-					<!-- Contact list -->
-					<div class="contact-list">
-						<div class="contact-list-header">
-							<label class="select-all-label">
-								<input
-									type="checkbox"
-									class="checkbox checkbox-sm checkbox-primary"
-									checked={selectAll}
-									onchange={toggleSelectAll}
-								/>
-								<span class="select-all-text">Select All</span>
-							</label>
+				{#if contactStats}
+					<div class="stats-badges">
+						<div class="badge badge-outline gap-1">
+							<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z" /><polyline points="22,6 12,13 2,6" /></svg>
+							{contactStats.withEmail} with email
 						</div>
-
-						{#each filteredContacts as contact, i}
-							<div class="contact-card" class:selected={contact.selected}>
-								<label class="contact-checkbox">
-									<input
-										type="checkbox"
-										class="checkbox checkbox-sm checkbox-primary"
-										bind:checked={contact.selected}
-									/>
-								</label>
-								<div class="contact-avatar">
-									<span>{contact.fn.charAt(0).toUpperCase()}</span>
-								</div>
-								<div class="contact-info">
-									<div class="contact-name">{contact.fn}</div>
-									<div class="contact-details">
-										{#if contact.email}
-											<span class="detail-item">
-												<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-													<path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z" />
-													<polyline points="22,6 12,13 2,6" />
-												</svg>
-												{contact.email}
-											</span>
-										{/if}
-										{#if contact.tel}
-											<span class="detail-item">
-												<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-													<path d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6 19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72 12.84 12.84 0 0 0 .7 2.81 2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 6 6l1.27-1.27a2 2 0 0 1 2.11-.45 12.84 12.84 0 0 0 2.81.7A2 2 0 0 1 22 16.92z" />
-												</svg>
-												{contact.tel}
-											</span>
-										{/if}
-										{#if contact.org}
-											<span class="detail-item">
-												<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-													<path d="M6 2L3 6v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V6l-3-4z" />
-													<line x1="3" y1="6" x2="21" y2="6" />
-												</svg>
-												{contact.org}
-											</span>
-										{/if}
-									</div>
-								</div>
-								<button
-									class="btn btn-sm btn-ghost btn-circle download-btn"
-									onclick={() => downloadSingle(contact)}
-									title="Download {contact.fn}.vcf"
-								>
-									<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-										<path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
-										<polyline points="7 10 12 15 17 10" />
-										<line x1="12" y1="15" x2="12" y2="3" />
-									</svg>
-								</button>
-							</div>
-						{/each}
-
-						{#if filteredContacts.length === 0 && searchQuery}
-							<div class="no-results">
-								<p>No contacts match "{searchQuery}"</p>
+						<div class="badge badge-outline gap-1">
+							<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6 19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72 12.84 12.84 0 0 0 .7 2.81 2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 6 6l1.27-1.27a2 2 0 0 1 2.11-.45 12.84 12.84 0 0 0 2.81.7A2 2 0 0 1 22 16.92z" /></svg>
+							{contactStats.withPhone} with phone
+						</div>
+						{#if contactStats.withOrg > 0}
+							<div class="badge badge-outline gap-1">
+								<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 2L3 6v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V6l-3-4z" /><line x1="3" y1="6" x2="21" y2="6" /></svg>
+								{contactStats.withOrg} with org
 							</div>
 						{/if}
 					</div>
+				{/if}
+			</div>
+
+			<!-- Search + download bar -->
+			<div class="toolbar">
+				<div class="search-box">
+					<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="search-icon">
+						<circle cx="11" cy="11" r="8" />
+						<line x1="21" y1="21" x2="16.65" y2="16.65" />
+					</svg>
+					<input
+						type="text"
+						class="input input-bordered input-sm search-input"
+						placeholder="Search contacts..."
+						bind:value={searchQuery}
+					/>
 				</div>
+			</div>
+
+			<!-- Contact list -->
+			<div class="contact-list">
+				<div class="contact-list-header">
+					<label class="select-all-label">
+						<input
+							type="checkbox"
+							class="checkbox checkbox-sm checkbox-primary"
+							checked={selectAll}
+							onchange={toggleSelectAll}
+						/>
+						<span>Select All</span>
+					</label>
+				</div>
+
+				{#each filteredContacts as contact}
+					<div class="contact-card" class:selected={contact.selected}>
+						<label class="contact-checkbox">
+							<input
+								type="checkbox"
+								class="checkbox checkbox-sm checkbox-primary"
+								bind:checked={contact.selected}
+							/>
+						</label>
+						<div class="contact-avatar">
+							<span>{contact.fn.charAt(0).toUpperCase()}</span>
+						</div>
+						<div class="contact-info">
+							<div class="contact-name">{contact.fn}</div>
+							<div class="contact-details">
+								{#if contact.email}
+									<span class="detail-item">
+										<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+											<path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z" />
+											<polyline points="22,6 12,13 2,6" />
+										</svg>
+										{contact.email}
+									</span>
+								{/if}
+								{#if contact.tel}
+									<span class="detail-item">
+										<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+											<path d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6 19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72 12.84 12.84 0 0 0 .7 2.81 2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 6 6l1.27-1.27a2 2 0 0 1 2.11-.45 12.84 12.84 0 0 0 2.81.7A2 2 0 0 1 22 16.92z" />
+										</svg>
+										{contact.tel}
+									</span>
+								{/if}
+								{#if contact.org}
+									<span class="detail-item">
+										<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+											<path d="M6 2L3 6v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V6l-3-4z" />
+											<line x1="3" y1="6" x2="21" y2="6" />
+										</svg>
+										{contact.org}
+									</span>
+								{/if}
+							</div>
+						</div>
+						<button
+							class="btn btn-sm btn-ghost btn-circle"
+							onclick={() => downloadSingle(contact)}
+							title="Download {contact.fn}.vcf"
+						>
+							<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+								<path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+								<polyline points="7 10 12 15 17 10" />
+								<line x1="12" y1="15" x2="12" y2="3" />
+							</svg>
+						</button>
+					</div>
+				{/each}
+
+				{#if filteredContacts.length === 0 && searchQuery}
+					<div class="no-results">
+						<p>No contacts match "{searchQuery}"</p>
+					</div>
+				{/if}
+			</div>
+		{/if}
+
+		<!-- Action buttons -->
+		<div class="action-buttons">
+			<button class="btn btn-primary btn-lg" onclick={splitContacts} disabled={!vcfInput.trim()}>
+				<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+					<path d="M16 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" />
+					<circle cx="8.5" cy="7" r="4" />
+					<line x1="20" y1="8" x2="20" y2="14" />
+					<line x1="23" y1="11" x2="17" y2="11" />
+				</svg>
+				Split Contacts
+			</button>
+			{#if contacts.length > 0}
+				<button class="btn btn-accent btn-lg" onclick={downloadAllZip} disabled={selectedCount === 0}>
+					<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+						<path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" /><polyline points="7 10 12 15 17 10" /><line x1="12" y1="15" x2="12" y2="3" />
+					</svg>
+					Download ZIP ({selectedCount})
+				</button>
 			{/if}
 		</div>
 
-		<!-- How it works section -->
+		<!-- Results section -->
+		{#if hasSplit}
+			<div class="results-section">
+				<div class="collapse collapse-arrow bg-base-100 border border-base-300">
+					<input type="checkbox" checked />
+					<div class="collapse-title">
+						<div class="results-header">
+							<h2 class="results-title text-primary">Split Results</h2>
+							<div class="results-summary">
+								{#if contacts.length > 0}
+									<span class="result-badge badge-success">{contacts.length} contact{contacts.length !== 1 ? 's' : ''} found</span>
+								{:else}
+									<span class="result-badge badge-error">No contacts found</span>
+								{/if}
+								{#if contacts.length > 0 && contactStats}
+									{#if contactStats.withEmail > 0}
+										<span class="result-badge badge-info">{contactStats.withEmail} with email</span>
+									{/if}
+									{#if contactStats.withPhone > 0}
+										<span class="result-badge badge-info">{contactStats.withPhone} with phone</span>
+									{/if}
+								{/if}
+							</div>
+						</div>
+					</div>
+					<div class="collapse-content">
+						<div class="issues-list">
+							{#if contacts.length === 0}
+								<div class="issue-item issue-error">
+									<span class="issue-icon">
+										<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+											<circle cx="12" cy="12" r="10" /><line x1="15" y1="9" x2="9" y2="15" /><line x1="9" y1="9" x2="15" y2="15" />
+										</svg>
+									</span>
+									<span>No BEGIN:VCARD / END:VCARD blocks found. Make sure your file is a valid .vcf file.</span>
+								</div>
+							{:else}
+								<div class="issue-item issue-fixed">
+									<span class="issue-icon">
+										<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+											<path d="M22 11.08V12a10 10 0 1 1-5.93-9.14" /><polyline points="22 4 12 14.01 9 11.01" />
+										</svg>
+									</span>
+									<span>Successfully split {contacts.length} contact{contacts.length !== 1 ? 's' : ''} into individual vCard files.</span>
+								</div>
+								{#each contacts as contact, i}
+									<div class="issue-item issue-fixed">
+										<span class="issue-icon">
+											<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+												<path d="M22 11.08V12a10 10 0 1 1-5.93-9.14" /><polyline points="22 4 12 14.01 9 11.01" />
+											</svg>
+										</span>
+										<span>Contact #{i + 1}: {contact.fn}{contact.email ? ` (${contact.email})` : ''}{contact.tel ? ` — ${contact.tel}` : ''}</span>
+									</div>
+								{/each}
+							{/if}
+						</div>
+					</div>
+				</div>
+			</div>
+		{/if}
+
+		<!-- Info section -->
 		<div class="info-section">
-			<h2 class="info-title">How to Import Contacts to iPhone</h2>
+			<h3 class="info-title text-primary">How to import contacts to iPhone</h3>
 			<div class="info-grid">
 				<div class="info-card">
 					<strong>1. Upload</strong>
-					<span>Drop your .vcf file above or tap "Upload"</span>
+					<span class="text-secondary">Paste or drop your .vcf file in the editor tab</span>
 				</div>
 				<div class="info-card">
-					<strong>2. Review</strong>
-					<span>Check the contacts found and deselect any you don't need</span>
+					<strong>2. Split</strong>
+					<span class="text-secondary">Click "Split Contacts" to separate each contact into its own file</span>
 				</div>
 				<div class="info-card">
-					<strong>3. Download ZIP</strong>
-					<span>Download all selected contacts as individual .vcf files in a ZIP</span>
+					<strong>3. Review</strong>
+					<span class="text-secondary">Switch to the Contacts tab to verify names, emails, and phone numbers</span>
 				</div>
 				<div class="info-card">
-					<strong>4. Import</strong>
-					<span>Unzip and open each .vcf file on your iPhone, or use iCloud Contacts import</span>
+					<strong>4. Download ZIP</strong>
+					<span class="text-secondary">Download all contacts as individual .vcf files in a ZIP archive</span>
+				</div>
+				<div class="info-card">
+					<strong>5. Import</strong>
+					<span class="text-secondary">Unzip and AirDrop each .vcf to your iPhone, or import via iCloud Contacts</span>
+				</div>
+				<div class="info-card">
+					<strong>Privacy</strong>
+					<span class="text-secondary">All processing runs locally in your browser — nothing is uploaded to any server</span>
 				</div>
 			</div>
 		</div>
-
-		<!-- Privacy note -->
-		<div class="privacy-note">
-			<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-				<rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
-				<path d="M7 11V7a5 5 0 0 1 10 0v4" />
-			</svg>
-			<span>Your data stays private. All processing happens locally in your browser — nothing is uploaded to any server.</span>
-		</div>
 	</div>
 
-	<!-- Footer -->
 	<footer class="page-footer">
-		<a href="/" class="back-link text-secondary">
-			<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-				<line x1="19" y1="12" x2="5" y2="12" />
-				<polyline points="12 19 5 12 12 5" />
+		<a href="/" class="back-link text-secondary hover:text-accent">
+			<svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+				<path
+					d="M12.5 8H3.5M3.5 8L7.5 4M3.5 8L7.5 12"
+					stroke="currentColor"
+					stroke-width="1.5"
+					stroke-linecap="round"
+					stroke-linejoin="round"
+				/>
 			</svg>
-			Back to Home
+			<span>Back to home</span>
 		</a>
 	</footer>
 </article>
 
 <style>
-	/* Page base */
 	.vcf-page {
-		max-width: 800px;
+		max-width: 1100px;
 		margin: 0 auto;
-		padding: 5rem 2rem 4rem;
+		padding: 4rem 2rem 6rem;
 		opacity: 0;
-		transform: translateY(16px);
-		transition: opacity 0.5s cubic-bezier(0.16, 1, 0.3, 1),
-			transform 0.5s cubic-bezier(0.16, 1, 0.3, 1);
+		transform: translateY(20px);
+		transition: all 0.6s var(--ease-out-expo, cubic-bezier(0.16, 1, 0.3, 1));
 	}
 
 	.vcf-page.visible {
@@ -530,79 +645,55 @@ END:VCARD`;
 		transform: translateY(0);
 	}
 
-	/* Header */
 	.page-header {
 		margin-bottom: 2.5rem;
+		text-align: center;
 	}
 
 	.page-title {
-		font-size: 2.25rem;
-		font-weight: 800;
-		letter-spacing: -0.03em;
-		line-height: 1.1;
+		font-size: 2.5rem;
+		font-weight: 700;
 		margin: 0 0 0.75rem;
+		letter-spacing: -0.03em;
 	}
 
 	.page-subtitle {
 		font-size: 1rem;
-		line-height: 1.6;
 		margin: 0;
-		max-width: 600px;
+		max-width: 540px;
+		margin-inline: auto;
+		line-height: 1.6;
 	}
 
-	/* Container */
 	.vcf-container {
 		display: flex;
 		flex-direction: column;
-		gap: 2rem;
+		gap: 1.5rem;
 	}
 
-	/* Upload zone */
-	.upload-zone {
-		border: 2px dashed oklch(var(--bc) / 0.15);
-		border-radius: 1rem;
-		padding: 3rem 2rem;
-		text-align: center;
-		transition: all 0.2s ease;
-		position: relative;
+	/* Tabs */
+	.tabs {
+		margin-bottom: 0.5rem;
 	}
 
-	.upload-zone.dragging {
-		border-color: oklch(0.6 0.2 250);
-		background: oklch(0.95 0.03 250 / 0.5);
+	.tab {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.25rem;
 	}
 
-	.upload-zone:hover {
-		border-color: oklch(var(--bc) / 0.25);
-	}
-
-	.upload-prompt {
+	/* Input section */
+	.input-section {
 		display: flex;
 		flex-direction: column;
-		align-items: center;
 		gap: 0.75rem;
 	}
 
-	.upload-icon {
-		color: oklch(var(--bc) / 0.3);
-	}
-
-	.upload-text {
-		font-size: 1.0625rem;
-		font-weight: 600;
-		margin: 0;
-	}
-
-	.upload-hint {
-		font-size: 0.8125rem;
-		color: oklch(var(--bc) / 0.5);
-		margin: 0;
-	}
-
-	.upload-actions {
+	.input-actions {
 		display: flex;
-		gap: 0.75rem;
-		margin-top: 0.5rem;
+		gap: 0.5rem;
+		flex-wrap: wrap;
+		align-items: center;
 	}
 
 	.upload-btn {
@@ -611,56 +702,86 @@ END:VCARD`;
 		gap: 0.375rem;
 	}
 
+	.textarea-wrapper {
+		position: relative;
+		border-radius: 1rem;
+		transition: box-shadow 0.2s ease;
+	}
+
+	.textarea-wrapper.dragging {
+		box-shadow: 0 0 0 3px oklch(0.7 0.15 250 / 0.4);
+	}
+
 	.drop-overlay {
+		position: absolute;
+		inset: 0;
 		display: flex;
 		flex-direction: column;
 		align-items: center;
 		justify-content: center;
-		gap: 0.75rem;
-		padding: 3rem;
+		gap: 0.5rem;
+		background: oklch(0.95 0.03 250 / 0.95);
+		border-radius: 1rem;
+		z-index: 10;
 		font-weight: 500;
 		color: oklch(0.5 0.15 250);
+		pointer-events: none;
 	}
 
-	/* Results */
-	.results-section {
+	.vcf-textarea {
+		font-family: 'SF Mono', 'Fira Code', 'Fira Mono', 'Cascadia Code', monospace;
+		font-size: 0.8125rem;
+		line-height: 1.5;
+		resize: vertical;
+		min-height: 200px;
+		width: 100%;
+	}
+
+	/* Action buttons */
+	.action-buttons {
 		display: flex;
-		flex-direction: column;
-		gap: 1rem;
+		justify-content: center;
+		gap: 0.75rem;
+		flex-wrap: wrap;
 	}
 
-	.results-header {
+	.action-buttons .btn {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.5rem;
+	}
+
+	/* Stats bar */
+	.stats-bar {
 		display: flex;
 		align-items: center;
 		justify-content: space-between;
 		flex-wrap: wrap;
 		gap: 0.75rem;
+		padding: 0.75rem 1rem;
+		background: oklch(var(--b2));
+		border-radius: 1rem;
+		border: 1px solid oklch(var(--bc) / 0.08);
 	}
 
-	.results-info {
+	.stats-info {
 		display: flex;
 		align-items: center;
-		gap: 0.75rem;
-		flex-wrap: wrap;
-	}
-
-	.results-title {
-		font-size: 1.25rem;
-		font-weight: 700;
-		margin: 0;
-	}
-
-	.results-actions {
-		display: flex;
 		gap: 0.5rem;
-		align-items: center;
+		font-weight: 600;
+		font-size: 0.875rem;
+	}
+
+	.stats-badges {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.375rem;
 	}
 
 	/* Toolbar */
 	.toolbar {
 		display: flex;
 		align-items: center;
-		justify-content: space-between;
 		gap: 0.75rem;
 		flex-wrap: wrap;
 	}
@@ -669,7 +790,7 @@ END:VCARD`;
 		position: relative;
 		flex: 1;
 		min-width: 180px;
-		max-width: 320px;
+		max-width: 400px;
 	}
 
 	.search-icon {
@@ -686,24 +807,20 @@ END:VCARD`;
 		width: 100%;
 	}
 
-	.bulk-actions {
-		display: flex;
-		gap: 0.5rem;
-	}
-
 	/* Contact list */
 	.contact-list {
 		display: flex;
 		flex-direction: column;
 		gap: 0;
 		border: 1px solid oklch(var(--bc) / 0.1);
-		border-radius: 0.75rem;
+		border-radius: 1rem;
 		overflow: hidden;
+		background: oklch(var(--b1));
 	}
 
 	.contact-list-header {
 		padding: 0.625rem 1rem;
-		background: oklch(var(--bc) / 0.03);
+		background: oklch(var(--b2));
 		border-bottom: 1px solid oklch(var(--bc) / 0.1);
 	}
 
@@ -784,15 +901,89 @@ END:VCARD`;
 		color: oklch(var(--bc) / 0.55);
 	}
 
-	.download-btn {
-		flex-shrink: 0;
-	}
-
 	.no-results {
 		padding: 2rem;
 		text-align: center;
 		color: oklch(var(--bc) / 0.5);
 		font-size: 0.875rem;
+	}
+
+	/* Results section */
+	.results-section {
+		border-radius: 1rem;
+	}
+
+	.results-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		flex-wrap: wrap;
+		gap: 0.75rem;
+	}
+
+	.results-title {
+		font-size: 1.125rem;
+		font-weight: 600;
+		margin: 0;
+	}
+
+	.results-summary {
+		display: flex;
+		gap: 0.375rem;
+		flex-wrap: wrap;
+	}
+
+	.result-badge {
+		font-size: 0.75rem;
+		font-weight: 600;
+		padding: 0.25rem 0.625rem;
+		border-radius: 999px;
+	}
+
+	.result-badge.badge-error {
+		background: oklch(0.93 0.06 25);
+		color: oklch(0.45 0.15 25);
+	}
+
+	.result-badge.badge-success {
+		background: oklch(0.93 0.06 150);
+		color: oklch(0.4 0.12 150);
+	}
+
+	.result-badge.badge-info {
+		background: oklch(0.93 0.06 250);
+		color: oklch(0.4 0.12 250);
+	}
+
+	.issues-list {
+		display: flex;
+		flex-direction: column;
+		gap: 0.375rem;
+	}
+
+	.issue-item {
+		display: flex;
+		align-items: flex-start;
+		gap: 0.5rem;
+		padding: 0.5rem 0.75rem;
+		border-radius: 8px;
+		font-size: 0.8125rem;
+		line-height: 1.4;
+	}
+
+	.issue-icon {
+		flex-shrink: 0;
+		margin-top: 1px;
+	}
+
+	.issue-error {
+		background: oklch(0.95 0.04 25);
+		color: oklch(0.45 0.15 25);
+	}
+
+	.issue-fixed {
+		background: oklch(0.95 0.04 150);
+		color: oklch(0.4 0.12 150);
 	}
 
 	/* Info section */
@@ -810,7 +1001,7 @@ END:VCARD`;
 
 	.info-grid {
 		display: grid;
-		grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+		grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
 		gap: 0.75rem;
 	}
 
@@ -827,23 +1018,6 @@ END:VCARD`;
 
 	.info-card strong {
 		font-size: 0.875rem;
-	}
-
-	/* Privacy note */
-	.privacy-note {
-		display: flex;
-		align-items: center;
-		gap: 0.5rem;
-		padding: 0.875rem 1rem;
-		background: oklch(0.95 0.03 150 / 0.5);
-		border-radius: 8px;
-		font-size: 0.8125rem;
-		color: oklch(0.4 0.1 150);
-		line-height: 1.4;
-	}
-
-	.privacy-note svg {
-		flex-shrink: 0;
 	}
 
 	/* Footer */
@@ -884,34 +1058,22 @@ END:VCARD`;
 			font-size: 1.75rem;
 		}
 
-		.upload-zone {
-			padding: 2rem 1rem;
-		}
-
 		.info-grid {
 			grid-template-columns: 1fr;
-		}
-
-		.toolbar {
-			flex-direction: column;
-			align-items: stretch;
-		}
-
-		.search-box {
-			max-width: none;
-		}
-
-		.bulk-actions {
-			justify-content: stretch;
-		}
-
-		.bulk-actions .btn {
-			flex: 1;
 		}
 
 		.results-header {
 			flex-direction: column;
 			align-items: flex-start;
+		}
+
+		.stats-bar {
+			flex-direction: column;
+			align-items: flex-start;
+		}
+
+		.stats-badges {
+			width: 100%;
 		}
 
 		.contact-details {

--- a/src/routes/vcf-splitter/+page.svelte
+++ b/src/routes/vcf-splitter/+page.svelte
@@ -1,0 +1,922 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import JSZip from 'jszip';
+
+	let visible = $state(false);
+	let isDragging = $state(false);
+	let searchQuery = $state('');
+	let selectAll = $state(true);
+
+	interface Contact {
+		raw: string;
+		fn: string;
+		email: string;
+		tel: string;
+		org: string;
+		selected: boolean;
+	}
+
+	let contacts: Contact[] = $state([]);
+	let fileName = $state('');
+
+	const SAMPLE_VCF = `BEGIN:VCARD
+VERSION:3.0
+FN:Taro Yamada
+N:Yamada;Taro;;;
+TEL;TYPE=CELL:+81-90-1234-5678
+EMAIL:taro@example.com
+ORG:Tokyo Corp
+END:VCARD
+BEGIN:VCARD
+VERSION:3.0
+FN:Sakura Tanaka
+N:Tanaka;Sakura;;;
+TEL;TYPE=CELL:+81-80-9876-5432
+EMAIL:sakura.tanaka@example.com
+ORG:Osaka Inc
+END:VCARD
+BEGIN:VCARD
+VERSION:3.0
+FN:John Smith
+N:Smith;John;;;
+TEL;TYPE=CELL:+1-555-0123
+TEL;TYPE=WORK:+1-555-0456
+EMAIL;TYPE=WORK:john.smith@acme.com
+EMAIL;TYPE=HOME:john@gmail.com
+ORG:Acme Corp
+TITLE:Engineering Manager
+ADR;TYPE=WORK:;;123 Main St;San Francisco;CA;94105;US
+END:VCARD
+BEGIN:VCARD
+VERSION:3.0
+FN:Yuki Sato
+N:Sato;Yuki;;;
+TEL;TYPE=CELL:+81-70-5555-1234
+EMAIL:yuki.sato@startup.jp
+ORG:Startup LLC
+END:VCARD
+BEGIN:VCARD
+VERSION:3.0
+FN:Maria Garcia
+N:Garcia;Maria;;;
+TEL;TYPE=CELL:+34-612-345-678
+EMAIL:maria@example.es
+ORG:Barcelona Design Studio
+END:VCARD`;
+
+	onMount(() => {
+		requestAnimationFrame(() => {
+			visible = true;
+		});
+	});
+
+	function parseVcf(text: string): Contact[] {
+		// Normalize line endings and unfold continuation lines
+		const normalized = text.replace(/\r\n/g, '\n').replace(/\r/g, '\n').replace(/\n[ \t]/g, '');
+
+		const result: Contact[] = [];
+		const vcardRegex = /BEGIN:VCARD[\s\S]*?END:VCARD/gi;
+		let match;
+
+		while ((match = vcardRegex.exec(normalized)) !== null) {
+			const block = match[0];
+			const lines = block.split('\n');
+
+			let fn = '';
+			let email = '';
+			let tel = '';
+			let org = '';
+
+			for (const line of lines) {
+				const upper = line.toUpperCase();
+
+				if (upper.startsWith('FN:') || upper.startsWith('FN;')) {
+					fn = extractValue(line);
+				} else if (!fn && (upper.startsWith('N:') || upper.startsWith('N;'))) {
+					// Fallback: construct from N field (Last;First;Middle;Prefix;Suffix)
+					const parts = extractValue(line).split(';');
+					const first = parts[1] || '';
+					const last = parts[0] || '';
+					fn = `${first} ${last}`.trim();
+				} else if (!email && (upper.startsWith('EMAIL:') || upper.startsWith('EMAIL;'))) {
+					email = extractValue(line);
+				} else if (!tel && (upper.startsWith('TEL:') || upper.startsWith('TEL;'))) {
+					tel = extractValue(line);
+				} else if (!org && (upper.startsWith('ORG:') || upper.startsWith('ORG;'))) {
+					org = extractValue(line).replace(/;+$/, '');
+				}
+			}
+
+			result.push({
+				raw: block.trim(),
+				fn: fn || 'Unknown',
+				email,
+				tel,
+				org,
+				selected: true,
+			});
+		}
+
+		return result;
+	}
+
+	function extractValue(line: string): string {
+		// Handle property parameters: PROP;PARAM=VAL:actual value
+		const colonIdx = line.indexOf(':');
+		if (colonIdx === -1) return '';
+		return line.substring(colonIdx + 1).trim();
+	}
+
+	function handleFileUpload(event: Event) {
+		const input = event.target as HTMLInputElement;
+		const file = input.files?.[0];
+		if (!file) return;
+		fileName = file.name;
+		const reader = new FileReader();
+		reader.onload = (e) => {
+			const text = (e.target?.result as string) || '';
+			contacts = parseVcf(text);
+			selectAll = true;
+		};
+		reader.readAsText(file);
+	}
+
+	function handleDrop(event: DragEvent) {
+		event.preventDefault();
+		isDragging = false;
+		const file = event.dataTransfer?.files?.[0];
+		if (!file) return;
+		fileName = file.name;
+		const reader = new FileReader();
+		reader.onload = (e) => {
+			const text = (e.target?.result as string) || '';
+			contacts = parseVcf(text);
+			selectAll = true;
+		};
+		reader.readAsText(file);
+	}
+
+	function handleDragOver(event: DragEvent) {
+		event.preventDefault();
+		isDragging = true;
+	}
+
+	function handleDragLeave() {
+		isDragging = false;
+	}
+
+	function loadSample() {
+		contacts = parseVcf(SAMPLE_VCF);
+		fileName = 'sample-contacts.vcf';
+		selectAll = true;
+	}
+
+	function clearAll() {
+		contacts = [];
+		fileName = '';
+		searchQuery = '';
+		selectAll = true;
+	}
+
+	function sanitizeFilename(name: string): string {
+		return name.replace(/[^a-zA-Z0-9_\-\s.]/g, '').replace(/\s+/g, '_') || 'contact';
+	}
+
+	function downloadSingle(contact: Contact) {
+		const blob = new Blob([contact.raw + '\r\n'], { type: 'text/vcard;charset=utf-8' });
+		const url = URL.createObjectURL(blob);
+		const a = document.createElement('a');
+		a.href = url;
+		a.download = `${sanitizeFilename(contact.fn)}.vcf`;
+		document.body.appendChild(a);
+		a.click();
+		document.body.removeChild(a);
+		URL.revokeObjectURL(url);
+	}
+
+	async function downloadAllZip() {
+		const selected = contacts.filter((c) => c.selected);
+		if (selected.length === 0) return;
+
+		const zip = new JSZip();
+		const usedNames = new Map<string, number>();
+
+		for (const contact of selected) {
+			let name = sanitizeFilename(contact.fn);
+			const count = usedNames.get(name) || 0;
+			if (count > 0) {
+				name = `${name}_${count}`;
+			}
+			usedNames.set(sanitizeFilename(contact.fn), count + 1);
+			zip.file(`${name}.vcf`, contact.raw + '\r\n');
+		}
+
+		const blob = await zip.generateAsync({ type: 'blob' });
+		const url = URL.createObjectURL(blob);
+		const a = document.createElement('a');
+		a.href = url;
+		const baseName = fileName ? fileName.replace(/\.vcf$/i, '') : 'contacts';
+		a.download = `${baseName}_split.zip`;
+		document.body.appendChild(a);
+		a.click();
+		document.body.removeChild(a);
+		URL.revokeObjectURL(url);
+	}
+
+	function toggleSelectAll() {
+		selectAll = !selectAll;
+		for (const c of filteredContacts) {
+			c.selected = selectAll;
+		}
+	}
+
+	let filteredContacts = $derived.by(() => {
+		if (!searchQuery.trim()) return contacts;
+		const q = searchQuery.toLowerCase();
+		return contacts.filter(
+			(c) =>
+				c.fn.toLowerCase().includes(q) ||
+				c.email.toLowerCase().includes(q) ||
+				c.tel.includes(q) ||
+				c.org.toLowerCase().includes(q)
+		);
+	});
+
+	let selectedCount = $derived(contacts.filter((c) => c.selected).length);
+</script>
+
+<svelte:head>
+	<title>VCF Splitter - Split Contacts into Individual Files - Hiro Kuwana</title>
+	<meta
+		name="description"
+		content="Split a single VCF file containing multiple contacts into individual vCard files. Perfect for importing contacts to iPhone, Android, or any device. Free, private, runs entirely in your browser."
+	/>
+	<meta name="keywords" content="vcf splitter, vcard splitter, split contacts, vcf to individual files, iphone contacts import, vcard converter" />
+	<meta property="og:title" content="VCF Splitter - Split Contacts into Individual Files" />
+	<meta property="og:description" content="Split a multi-contact VCF file into individual vCard files for easy import to iPhone, Android, or any device." />
+	<meta property="og:type" content="website" />
+</svelte:head>
+
+<article class="vcf-page" class:visible>
+	<header class="page-header">
+		<h1 class="page-title text-primary">VCF File Splitter</h1>
+		<p class="page-subtitle text-secondary">
+			Upload a .vcf file with multiple contacts and split it into individual vCard files.
+			Download them all as a ZIP or one at a time. Everything runs in your browser — no data leaves your device.
+		</p>
+	</header>
+
+	<div class="vcf-container">
+		<!-- Upload section -->
+		<div
+			class="upload-section"
+			class:dragging={isDragging}
+			ondrop={handleDrop}
+			ondragover={handleDragOver}
+			ondragleave={handleDragLeave}
+			role="region"
+			aria-label="VCF file upload"
+		>
+			{#if contacts.length === 0}
+				<div class="upload-zone" class:dragging={isDragging}>
+					{#if isDragging}
+						<div class="drop-overlay">
+							<svg width="40" height="40" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+								<path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+								<polyline points="17 8 12 3 7 8" />
+								<line x1="12" y1="3" x2="12" y2="15" />
+							</svg>
+							<span>Drop your .vcf file here</span>
+						</div>
+					{:else}
+						<div class="upload-prompt">
+							<svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" class="upload-icon">
+								<path d="M16 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" />
+								<circle cx="8.5" cy="7" r="4" />
+								<line x1="20" y1="8" x2="20" y2="14" />
+								<line x1="23" y1="11" x2="17" y2="11" />
+							</svg>
+							<p class="upload-text">Drag & drop your .vcf file here</p>
+							<p class="upload-hint">or use the buttons below</p>
+							<div class="upload-actions">
+								<label class="btn btn-primary upload-btn">
+									<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+										<path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+										<polyline points="17 8 12 3 7 8" />
+										<line x1="12" y1="3" x2="12" y2="15" />
+									</svg>
+									Upload .vcf File
+									<input
+										type="file"
+										accept=".vcf,.vcard"
+										onchange={handleFileUpload}
+										class="hidden"
+									/>
+								</label>
+								<button class="btn btn-outline btn-secondary" onclick={loadSample}>
+									Load Sample
+								</button>
+							</div>
+						</div>
+					{/if}
+				</div>
+			{:else}
+				<!-- Results section -->
+				<div class="results-section">
+					<div class="results-header">
+						<div class="results-info">
+							<h2 class="results-title">
+								{contacts.length} Contact{contacts.length !== 1 ? 's' : ''} Found
+							</h2>
+							{#if fileName}
+								<span class="file-badge badge badge-outline badge-sm gap-1">
+									<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+										<path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+										<polyline points="14 2 14 8 20 8" />
+									</svg>
+									{fileName}
+								</span>
+							{/if}
+						</div>
+						<div class="results-actions">
+							<label class="btn btn-sm btn-outline btn-secondary upload-btn">
+								<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+									<path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+									<polyline points="17 8 12 3 7 8" />
+									<line x1="12" y1="3" x2="12" y2="15" />
+								</svg>
+								New File
+								<input
+									type="file"
+									accept=".vcf,.vcard"
+									onchange={handleFileUpload}
+									class="hidden"
+								/>
+							</label>
+							<button class="btn btn-sm btn-ghost text-secondary" onclick={clearAll}>Clear</button>
+						</div>
+					</div>
+
+					<!-- Search and actions bar -->
+					<div class="toolbar">
+						<div class="search-box">
+							<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="search-icon">
+								<circle cx="11" cy="11" r="8" />
+								<line x1="21" y1="21" x2="16.65" y2="16.65" />
+							</svg>
+							<input
+								type="text"
+								class="input input-bordered input-sm search-input"
+								placeholder="Search contacts..."
+								bind:value={searchQuery}
+							/>
+						</div>
+						<div class="bulk-actions">
+							<button
+								class="btn btn-sm btn-primary gap-2"
+								onclick={downloadAllZip}
+								disabled={selectedCount === 0}
+							>
+								<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+									<path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+									<polyline points="7 10 12 15 17 10" />
+									<line x1="12" y1="15" x2="12" y2="3" />
+								</svg>
+								Download ZIP ({selectedCount})
+							</button>
+						</div>
+					</div>
+
+					<!-- Contact list -->
+					<div class="contact-list">
+						<div class="contact-list-header">
+							<label class="select-all-label">
+								<input
+									type="checkbox"
+									class="checkbox checkbox-sm checkbox-primary"
+									checked={selectAll}
+									onchange={toggleSelectAll}
+								/>
+								<span class="select-all-text">Select All</span>
+							</label>
+						</div>
+
+						{#each filteredContacts as contact, i}
+							<div class="contact-card" class:selected={contact.selected}>
+								<label class="contact-checkbox">
+									<input
+										type="checkbox"
+										class="checkbox checkbox-sm checkbox-primary"
+										bind:checked={contact.selected}
+									/>
+								</label>
+								<div class="contact-avatar">
+									<span>{contact.fn.charAt(0).toUpperCase()}</span>
+								</div>
+								<div class="contact-info">
+									<div class="contact-name">{contact.fn}</div>
+									<div class="contact-details">
+										{#if contact.email}
+											<span class="detail-item">
+												<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+													<path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z" />
+													<polyline points="22,6 12,13 2,6" />
+												</svg>
+												{contact.email}
+											</span>
+										{/if}
+										{#if contact.tel}
+											<span class="detail-item">
+												<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+													<path d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6 19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72 12.84 12.84 0 0 0 .7 2.81 2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 6 6l1.27-1.27a2 2 0 0 1 2.11-.45 12.84 12.84 0 0 0 2.81.7A2 2 0 0 1 22 16.92z" />
+												</svg>
+												{contact.tel}
+											</span>
+										{/if}
+										{#if contact.org}
+											<span class="detail-item">
+												<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+													<path d="M6 2L3 6v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V6l-3-4z" />
+													<line x1="3" y1="6" x2="21" y2="6" />
+												</svg>
+												{contact.org}
+											</span>
+										{/if}
+									</div>
+								</div>
+								<button
+									class="btn btn-sm btn-ghost btn-circle download-btn"
+									onclick={() => downloadSingle(contact)}
+									title="Download {contact.fn}.vcf"
+								>
+									<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+										<path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+										<polyline points="7 10 12 15 17 10" />
+										<line x1="12" y1="15" x2="12" y2="3" />
+									</svg>
+								</button>
+							</div>
+						{/each}
+
+						{#if filteredContacts.length === 0 && searchQuery}
+							<div class="no-results">
+								<p>No contacts match "{searchQuery}"</p>
+							</div>
+						{/if}
+					</div>
+				</div>
+			{/if}
+		</div>
+
+		<!-- How it works section -->
+		<div class="info-section">
+			<h2 class="info-title">How to Import Contacts to iPhone</h2>
+			<div class="info-grid">
+				<div class="info-card">
+					<strong>1. Upload</strong>
+					<span>Drop your .vcf file above or tap "Upload"</span>
+				</div>
+				<div class="info-card">
+					<strong>2. Review</strong>
+					<span>Check the contacts found and deselect any you don't need</span>
+				</div>
+				<div class="info-card">
+					<strong>3. Download ZIP</strong>
+					<span>Download all selected contacts as individual .vcf files in a ZIP</span>
+				</div>
+				<div class="info-card">
+					<strong>4. Import</strong>
+					<span>Unzip and open each .vcf file on your iPhone, or use iCloud Contacts import</span>
+				</div>
+			</div>
+		</div>
+
+		<!-- Privacy note -->
+		<div class="privacy-note">
+			<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+				<rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
+				<path d="M7 11V7a5 5 0 0 1 10 0v4" />
+			</svg>
+			<span>Your data stays private. All processing happens locally in your browser — nothing is uploaded to any server.</span>
+		</div>
+	</div>
+
+	<!-- Footer -->
+	<footer class="page-footer">
+		<a href="/" class="back-link text-secondary">
+			<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+				<line x1="19" y1="12" x2="5" y2="12" />
+				<polyline points="12 19 5 12 12 5" />
+			</svg>
+			Back to Home
+		</a>
+	</footer>
+</article>
+
+<style>
+	/* Page base */
+	.vcf-page {
+		max-width: 800px;
+		margin: 0 auto;
+		padding: 5rem 2rem 4rem;
+		opacity: 0;
+		transform: translateY(16px);
+		transition: opacity 0.5s cubic-bezier(0.16, 1, 0.3, 1),
+			transform 0.5s cubic-bezier(0.16, 1, 0.3, 1);
+	}
+
+	.vcf-page.visible {
+		opacity: 1;
+		transform: translateY(0);
+	}
+
+	/* Header */
+	.page-header {
+		margin-bottom: 2.5rem;
+	}
+
+	.page-title {
+		font-size: 2.25rem;
+		font-weight: 800;
+		letter-spacing: -0.03em;
+		line-height: 1.1;
+		margin: 0 0 0.75rem;
+	}
+
+	.page-subtitle {
+		font-size: 1rem;
+		line-height: 1.6;
+		margin: 0;
+		max-width: 600px;
+	}
+
+	/* Container */
+	.vcf-container {
+		display: flex;
+		flex-direction: column;
+		gap: 2rem;
+	}
+
+	/* Upload zone */
+	.upload-zone {
+		border: 2px dashed oklch(var(--bc) / 0.15);
+		border-radius: 1rem;
+		padding: 3rem 2rem;
+		text-align: center;
+		transition: all 0.2s ease;
+		position: relative;
+	}
+
+	.upload-zone.dragging {
+		border-color: oklch(0.6 0.2 250);
+		background: oklch(0.95 0.03 250 / 0.5);
+	}
+
+	.upload-zone:hover {
+		border-color: oklch(var(--bc) / 0.25);
+	}
+
+	.upload-prompt {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 0.75rem;
+	}
+
+	.upload-icon {
+		color: oklch(var(--bc) / 0.3);
+	}
+
+	.upload-text {
+		font-size: 1.0625rem;
+		font-weight: 600;
+		margin: 0;
+	}
+
+	.upload-hint {
+		font-size: 0.8125rem;
+		color: oklch(var(--bc) / 0.5);
+		margin: 0;
+	}
+
+	.upload-actions {
+		display: flex;
+		gap: 0.75rem;
+		margin-top: 0.5rem;
+	}
+
+	.upload-btn {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.375rem;
+	}
+
+	.drop-overlay {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+		gap: 0.75rem;
+		padding: 3rem;
+		font-weight: 500;
+		color: oklch(0.5 0.15 250);
+	}
+
+	/* Results */
+	.results-section {
+		display: flex;
+		flex-direction: column;
+		gap: 1rem;
+	}
+
+	.results-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		flex-wrap: wrap;
+		gap: 0.75rem;
+	}
+
+	.results-info {
+		display: flex;
+		align-items: center;
+		gap: 0.75rem;
+		flex-wrap: wrap;
+	}
+
+	.results-title {
+		font-size: 1.25rem;
+		font-weight: 700;
+		margin: 0;
+	}
+
+	.results-actions {
+		display: flex;
+		gap: 0.5rem;
+		align-items: center;
+	}
+
+	/* Toolbar */
+	.toolbar {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 0.75rem;
+		flex-wrap: wrap;
+	}
+
+	.search-box {
+		position: relative;
+		flex: 1;
+		min-width: 180px;
+		max-width: 320px;
+	}
+
+	.search-icon {
+		position: absolute;
+		left: 0.75rem;
+		top: 50%;
+		transform: translateY(-50%);
+		color: oklch(var(--bc) / 0.4);
+		pointer-events: none;
+	}
+
+	.search-input {
+		padding-left: 2.25rem;
+		width: 100%;
+	}
+
+	.bulk-actions {
+		display: flex;
+		gap: 0.5rem;
+	}
+
+	/* Contact list */
+	.contact-list {
+		display: flex;
+		flex-direction: column;
+		gap: 0;
+		border: 1px solid oklch(var(--bc) / 0.1);
+		border-radius: 0.75rem;
+		overflow: hidden;
+	}
+
+	.contact-list-header {
+		padding: 0.625rem 1rem;
+		background: oklch(var(--bc) / 0.03);
+		border-bottom: 1px solid oklch(var(--bc) / 0.1);
+	}
+
+	.select-all-label {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		cursor: pointer;
+		font-size: 0.8125rem;
+		font-weight: 500;
+		color: oklch(var(--bc) / 0.6);
+	}
+
+	.contact-card {
+		display: flex;
+		align-items: center;
+		gap: 0.75rem;
+		padding: 0.75rem 1rem;
+		border-bottom: 1px solid oklch(var(--bc) / 0.06);
+		transition: background 0.15s ease;
+	}
+
+	.contact-card:last-child {
+		border-bottom: none;
+	}
+
+	.contact-card:hover {
+		background: oklch(var(--bc) / 0.02);
+	}
+
+	.contact-card.selected {
+		background: oklch(var(--p) / 0.03);
+	}
+
+	.contact-checkbox {
+		flex-shrink: 0;
+		display: flex;
+		align-items: center;
+	}
+
+	.contact-avatar {
+		flex-shrink: 0;
+		width: 36px;
+		height: 36px;
+		border-radius: 50%;
+		background: oklch(var(--p) / 0.12);
+		color: oklch(var(--p));
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		font-weight: 700;
+		font-size: 0.875rem;
+	}
+
+	.contact-info {
+		flex: 1;
+		min-width: 0;
+	}
+
+	.contact-name {
+		font-weight: 600;
+		font-size: 0.9375rem;
+		line-height: 1.3;
+	}
+
+	.contact-details {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.5rem;
+		margin-top: 0.125rem;
+	}
+
+	.detail-item {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.25rem;
+		font-size: 0.75rem;
+		color: oklch(var(--bc) / 0.55);
+	}
+
+	.download-btn {
+		flex-shrink: 0;
+	}
+
+	.no-results {
+		padding: 2rem;
+		text-align: center;
+		color: oklch(var(--bc) / 0.5);
+		font-size: 0.875rem;
+	}
+
+	/* Info section */
+	.info-section {
+		margin-top: 1rem;
+		padding-top: 2rem;
+		border-top: 1px solid oklch(var(--bc) / 0.1);
+	}
+
+	.info-title {
+		font-size: 1.125rem;
+		font-weight: 600;
+		margin: 0 0 1rem;
+	}
+
+	.info-grid {
+		display: grid;
+		grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+		gap: 0.75rem;
+	}
+
+	.info-card {
+		display: flex;
+		flex-direction: column;
+		gap: 0.25rem;
+		padding: 0.875rem 1rem;
+		border: 1px solid oklch(var(--bc) / 0.1);
+		border-radius: 8px;
+		font-size: 0.8125rem;
+		line-height: 1.4;
+	}
+
+	.info-card strong {
+		font-size: 0.875rem;
+	}
+
+	/* Privacy note */
+	.privacy-note {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		padding: 0.875rem 1rem;
+		background: oklch(0.95 0.03 150 / 0.5);
+		border-radius: 8px;
+		font-size: 0.8125rem;
+		color: oklch(0.4 0.1 150);
+		line-height: 1.4;
+	}
+
+	.privacy-note svg {
+		flex-shrink: 0;
+	}
+
+	/* Footer */
+	.page-footer {
+		margin-top: 4rem;
+		padding-top: 2rem;
+		border-top: 1px solid oklch(var(--bc) / 0.1);
+	}
+
+	.back-link {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.5rem;
+		font-size: 0.9375rem;
+		font-weight: 500;
+		text-decoration: none;
+		transition: all 0.2s ease;
+	}
+
+	.back-link:hover svg {
+		transform: translateX(-4px);
+	}
+
+	.back-link svg {
+		transition: transform 0.2s ease;
+	}
+
+	.hidden {
+		display: none;
+	}
+
+	@media (max-width: 640px) {
+		.vcf-page {
+			padding: 3rem 1.25rem 4rem;
+		}
+
+		.page-title {
+			font-size: 1.75rem;
+		}
+
+		.upload-zone {
+			padding: 2rem 1rem;
+		}
+
+		.info-grid {
+			grid-template-columns: 1fr;
+		}
+
+		.toolbar {
+			flex-direction: column;
+			align-items: stretch;
+		}
+
+		.search-box {
+			max-width: none;
+		}
+
+		.bulk-actions {
+			justify-content: stretch;
+		}
+
+		.bulk-actions .btn {
+			flex: 1;
+		}
+
+		.results-header {
+			flex-direction: column;
+			align-items: flex-start;
+		}
+
+		.contact-details {
+			flex-direction: column;
+			gap: 0.25rem;
+		}
+	}
+</style>

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -1,1 +1,0 @@
-import { expect, test } from '@playwright/test';


### PR DESCRIPTION
## Summary
Added a new VCF File Splitter tool that allows users to upload or paste a .vcf file containing multiple contacts, split them into individual vCard files, and download them as a ZIP archive. The tool runs entirely in the browser with no server-side processing.

## Key Changes
- **New page**: `src/routes/vcf-splitter/+page.svelte` - Complete VCF splitting application with:
  - VCF file parsing and validation with support for multiple contact formats
  - Drag-and-drop file upload with visual feedback
  - Tabbed interface for editor and contacts view
  - Contact list with search, filtering, and bulk selection
  - Individual and batch download capabilities (single .vcf or ZIP archive)
  - Contact statistics (email, phone, organization counts)
  - Sample VCF data for testing
  - Responsive design with mobile support
  - Detailed split results and import instructions

- **Updated**: `src/data/constants.ts` - Added VCF File Splitter to the TOOLS array with description and routing

- **Dependencies**: Added `jszip` package for ZIP file generation

## Implementation Details
- VCF parsing handles multiple vCard formats with proper line unfolding and normalization
- Extracts key contact fields: name (FN/N), email, phone, and organization
- Filename sanitization prevents invalid characters in exported files
- Duplicate filename handling with numeric suffixes
- Search functionality filters across all contact fields
- Select-all toggle for batch operations
- Comprehensive error handling and user feedback through results section
- Privacy-focused: all processing occurs client-side

https://claude.ai/code/session_01DuwMRWN3kmwu8sNrF9oVWc