### PR TITLE
Fix button animations when combining fade-in-up with pulse effect

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -166,6 +166,12 @@ a:focus-visible {
 .btn-cta-pulse {
 	animation: cta-glow 2.5s ease-in-out 3s 4;
 }
+/* When combined with fade-in-up, run both animations so the button still fades in */
+.animate-fade-in-up.btn-cta-pulse {
+	animation:
+		fadeInUp 0.7s var(--ease-out-expo) forwards,
+		cta-glow 2.5s ease-in-out 3s 4;
+}
 .btn-cta-pulse:hover,
 .btn-cta-pulse:focus-visible {
 	animation: none;


### PR DESCRIPTION
## Summary
Fixed an issue where the pulse animation was not running when a button had both the `fade-in-up` and `btn-cta-pulse` classes applied simultaneously.

## Key Changes
- Added a new CSS rule for `.animate-fade-in-up.btn-cta-pulse` that combines both animations
- The fade-in-up animation runs first (0.7s with expo easing) and completes before the pulse effect begins
- Both animations now execute properly instead of one overriding the other

## Implementation Details
The solution uses CSS animation stacking to run both animations in sequence:
1. `fadeInUp` animation completes the entrance effect (0.7s)
2. `cta-glow` pulse animation begins after the fade-in completes (3s delay, 4 iterations)

This ensures buttons that need both visual effects display them correctly without conflicts.

https://claude.ai/code/session_01P3Tux21w3Myb8zBMyaMUpH