### PR TITLE
Refocus portfolio to Kaiwa language coaching platform

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -84,8 +84,8 @@
 			'contact.tools.title': 'Side tools · 道具',
 			'contact.tools.vcf.label': 'vCard · save my contact',
 			'contact.tools.vcf.desc': 'A standard .vcf for your phone or address book.',
-			'contact.tools.ics.label': 'Coffee on the calendar',
-			'contact.tools.ics.desc': 'A .ics with my cal.com link, so the next chat is one click away.',
+			'contact.tools.ics.label': 'Tea on the calendar',
+			'contact.tools.ics.desc': 'A .ics with my cal.com link, so the next pot of tea is one click away.',
 			'contact.write.lead': "Tell me what you teach and where AI keeps getting in the way. No template, no automation, just you and me.",
 			'contact.field.name': 'お名前 · Name',
 			'contact.field.email': '電子メール · Email',
@@ -169,8 +169,8 @@
 			'contact.tools.title': '道具 · side tools',
 			'contact.tools.vcf.label': 'vCard · 連絡先を保存',
 			'contact.tools.vcf.desc': '電話帳や連絡先にそのまま取り込める .vcf。',
-			'contact.tools.ics.label': '予定にコーヒーを入れる',
-			'contact.tools.ics.desc': '私の cal.com のリンクが入った .ics。次の一杯までワンクリック。',
+			'contact.tools.ics.label': '予定にお茶を入れる',
+			'contact.tools.ics.desc': '私の cal.com のリンクが入った .ics。次の一服までワンクリック。',
 			'contact.write.lead': '何を教えているか、どこで AI に手間取っているか、教えてください。テンプレートも自動返信もなし、あなたと私だけです。',
 			'contact.field.name': '名前 · Name',
 			'contact.field.email': 'メール · Email',
@@ -731,7 +731,7 @@
 							<span>{t('contact.tools.vcf.desc')}</span>
 						</li>
 						<li>
-							<a href={asset('/coffee-with-hiro.ics')} download>{t('contact.tools.ics.label')}</a>
+							<a href={asset('/tea-with-hiro.ics')} download>{t('contact.tools.ics.label')}</a>
 							<span>{t('contact.tools.ics.desc')}</span>
 						</li>
 					</ul>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -38,13 +38,13 @@
 			'hero.title.l2': 'that augment',
 			'hero.title.l3': 'humanity',
 			'hero.tagline':
-				"I'm Hiro Kuwana (桑名浩行). I make practical, opinionated AI utilities, quietly built and carefully made, for people who would rather think than scroll.",
-			'hero.now': 'Open · three seats · this season',
-			'hero.about1.a': 'I write and make things. I take on a few focused projects each season, usually with founders or teams building human-centric products with AI. The aim is',
-			'hero.about1.strong': 'AI-fluent design that augments you, rather than becomes another chatbot.',
-			'hero.about1.b': 'Tools with taste, for people who think.',
+				"I'm Hiro Kuwana (桑名浩行). Most of my time goes to helping language coaches use AI — quietly, hands-on, so they get hours back each week and keep doing the human part of teaching.",
+			'hero.now': 'Now · AI help for language coaches · 3 seats',
+			'hero.about1.a': 'I work closely with a small number of language coaches each season, mostly Kaiwa coaches building real practice loops with their students. The aim is',
+			'hero.about1.strong': 'AI that gives you hours back, not another chatbot to babysit.',
+			'hero.about1.b': 'Practical workflows, set up with you, tuned to how you teach.',
 			'hero.about2':
-				'I keep notes here on product, language learning, and the slower questions underneath the work.',
+				'In the time around that, I write here about product, language learning, and the slower questions underneath the work.',
 			'hero.meta.based.k': 'Based',
 			'hero.meta.based.v': 'Tokyo · New York',
 			'hero.meta.since.k': 'Since',
@@ -79,15 +79,15 @@
 			'contact.titleEm': 'write me, or follow along.',
 			'contact.tab.write': 'Write me · お便り',
 			'contact.tab.follow': 'Follow new posts · 購読',
-			'contact.aside.lead': 'Open for one or two collaborations through autumn. Short engagements, deep work, real outcomes.',
-			'contact.aside.hi': 'Or just say hello. I read every message by hand and usually reply within a few days.',
-			'contact.write.lead': "Tell me what you're working on. No template, no automation, just you and me.",
+			'contact.aside.lead': 'If you teach languages and want to use AI without it eating your evenings, write me. I work hands-on with a few coaches at a time over a few weeks — outreach, lesson prep, the workflows that quietly steal your day.',
+			'contact.aside.hi': 'Not a coach? Still say hello. I read every message by hand and usually reply within a few days.',
+			'contact.write.lead': "Tell me what you teach and where AI keeps getting in the way. No template, no automation, just you and me.",
 			'contact.field.name': 'お名前 · Name',
 			'contact.field.email': '電子メール · Email',
 			'contact.field.msg': 'ご用件 · Message',
 			'contact.field.namePh': 'Your name',
 			'contact.field.emailPh': 'you@somewhere.com',
-			'contact.field.msgPh': "Tell me what you're working on, or just say hi.",
+			'contact.field.msgPh': 'What you teach, where AI keeps slowing you down, what you wish it would do.',
 			'contact.note.write': 'Opens your mail client as a fallback. Nothing is sent to a third party from this page.',
 			'contact.btn.send': 'Send · 送る →',
 			'contact.btn.sending': 'Sending...',
@@ -119,12 +119,12 @@
 			'hero.title.l2': '',
 			'hero.title.l3': '道具をつくる',
 			'hero.tagline':
-				'桑名浩行 (Hiro Kuwana) です。実用的で、ちょっと意地のある AI の道具を、静かに、ていねいに作っています。スクロールするより、考えたい人のために。',
-			'hero.now': '受付中 · 三件 · 今季',
-			'hero.about1.a': '書いたり、つくったりしています。季節ごとに数件、AI を使った人中心のプロダクトをつくるファウンダーやチームと組みます。目指すのは、',
-			'hero.about1.strong': 'もう一つのチャットボットではなく、あなたを拡張する、AI に馴染んだ設計。',
-			'hero.about1.b': '考える人のための、センスのある道具を。',
-			'hero.about2': 'ここでは、プロダクトや言語学習、そして仕事の奥にあるゆっくりした問いについて書いています。',
+				'桑名浩行 (Hiro Kuwana) です。最近は時間のほとんどを、語学コーチが AI で週に数時間を取り戻せるように、静かに、近くで一緒に整えることに使っています。教える人の、人間らしい仕事を残すために。',
+			'hero.now': '受付中 · 語学コーチの AI 支援 · 三席',
+			'hero.about1.a': '季節ごとに、数名の語学コーチと近くで仕事をしています。多くは Kaiwa で学習の道筋をつくっているコーチです。目指すのは、',
+			'hero.about1.strong': 'もう一つチャットボットを抱えるのではなく、時間を取り戻すための AI の使い方。',
+			'hero.about1.b': 'あなたの教え方に合わせて、実用的な仕組みを一緒に組み立てます。',
+			'hero.about2': 'その合間に、プロダクトや言語学習、そして仕事の奥にあるゆっくりした問いについて書いています。',
 			'hero.meta.based.k': '拠点',
 			'hero.meta.based.v': '東京 · ニューヨーク',
 			'hero.meta.since.k': '開始',
@@ -159,15 +159,15 @@
 			'contact.titleEm': 'お便りでも、購読でも。',
 			'contact.tab.write': 'お便りを書く · Write',
 			'contact.tab.follow': '更新を購読 · Follow',
-			'contact.aside.lead': '秋までに一、二件、ご一緒できます。短い期間で、深く、ちゃんと成果を。',
-			'contact.aside.hi': 'ひとことの挨拶でも歓迎です。届いたメッセージは全部自分で読んで、たいてい数日以内に返事します。',
-			'contact.write.lead': 'いま何をやっているか、教えてください。テンプレートも自動返信もなし、あなたと私だけです。',
+			'contact.aside.lead': '語学を教えていて、AI を使いたいけれど夜の時間まで取られたくない、という方は、ぜひお便りを。同時に数名のコーチと、数週間、近くで一緒に組み立てます。集客、授業準備、気づかぬうちに一日を奪う作業まで。',
+			'contact.aside.hi': 'コーチの方でなくても、ひとことの挨拶を歓迎します。届いたメッセージは全部自分で読んで、たいてい数日以内に返事します。',
+			'contact.write.lead': '何を教えているか、どこで AI に手間取っているか、教えてください。テンプレートも自動返信もなし、あなたと私だけです。',
 			'contact.field.name': '名前 · Name',
 			'contact.field.email': 'メール · Email',
 			'contact.field.msg': '用件 · Message',
 			'contact.field.namePh': '名前',
 			'contact.field.emailPh': 'you@somewhere.com',
-			'contact.field.msgPh': 'いま何を作っているか、ひとことでも。',
+			'contact.field.msgPh': '何を教えているか、どこで AI に時間を取られているか、何ができたら嬉しいか。',
 			'contact.note.write': 'お使いのメールアプリが代わりに開きます。このページから第三者には何も送りません。',
 			'contact.btn.send': '送る · Send →',
 			'contact.btn.sending': '送信中...',
@@ -483,10 +483,10 @@
 </script>
 
 <svelte:head>
-	<title>Hiro Kuwana · building tools that augment humanity</title>
+	<title>Hiro Kuwana · AI help for language coaches</title>
 	<meta
 		name="description"
-		content="Hiro Kuwana builds practical, opinionated AI tools and writes about product, language learning, and building for the long run."
+		content="Founder-led, hands-on AI help for language coaches — set up the workflows that give you hours back each week. Also notes on product, language learning, and building for the long run."
 	/>
 	<meta name="keywords" content={SITE.keywords.join(', ')} />
 	<meta name="author" content={SITE.author} />
@@ -494,16 +494,16 @@
 	<meta name="googlebot" content="index, follow" />
 	<meta property="og:type" content="profile" />
 	<meta property="og:url" content={SITE.url} />
-	<meta property="og:title" content="Hiro Kuwana · building tools that augment humanity" />
-	<meta property="og:description" content="A small studio of one for practical AI utilities, product notes, and slow essays." />
+	<meta property="og:title" content="Hiro Kuwana · AI help for language coaches" />
+	<meta property="og:description" content="Founder-led, hands-on AI help for language coaches. Plus product notes and slow essays." />
 	<meta property="og:image" content={SITE.image} />
 	<meta property="og:locale" content={lang === 'ja' ? 'ja_JP' : 'en_US'} />
 	<meta property="og:locale:alternate" content={lang === 'ja' ? 'en_US' : 'ja_JP'} />
 	<meta property="profile:first_name" content="Hiro" />
 	<meta property="profile:last_name" content="Kuwana" />
 	<meta name="twitter:card" content="summary_large_image" />
-	<meta name="twitter:title" content="Hiro Kuwana · building tools that augment humanity" />
-	<meta name="twitter:description" content="Practical AI utilities, product notes, and slow essays by Hiro Kuwana." />
+	<meta name="twitter:title" content="Hiro Kuwana · AI help for language coaches" />
+	<meta name="twitter:description" content="Founder-led, hands-on AI help for language coaches. Plus product notes and slow essays by Hiro Kuwana." />
 	<meta name="twitter:image" content={SITE.image} />
 	<link rel="canonical" href={SITE.url} />
 	<link rel="alternate" hreflang="en" href={SITE.url} />

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -81,6 +81,11 @@
 			'contact.tab.follow': 'Follow new posts · 購読',
 			'contact.aside.lead': 'If you teach languages — or want to — come build with us on Kaiwa. I work alongside our coaches: designing learner journeys, sorting out outreach, and quietly removing the workflows that steal your day.',
 			'contact.aside.hi': 'Not a coach? Still say hello. I read every message by hand and usually reply within a few days.',
+			'contact.tools.title': 'Side tools · 道具',
+			'contact.tools.vcf.label': 'vCard · save my contact',
+			'contact.tools.vcf.desc': 'A standard .vcf for your phone or address book.',
+			'contact.tools.ics.label': 'Coffee on the calendar',
+			'contact.tools.ics.desc': 'A .ics with my cal.com link, so the next chat is one click away.',
 			'contact.write.lead': "Tell me what you teach and where AI keeps getting in the way. No template, no automation, just you and me.",
 			'contact.field.name': 'お名前 · Name',
 			'contact.field.email': '電子メール · Email',
@@ -161,6 +166,11 @@
 			'contact.tab.follow': '更新を購読 · Follow',
 			'contact.aside.lead': '語学を教えている、あるいは教えたいと思っている方は、ぜひ Kaiwa で一緒につくりましょう。コーチと並んで、学習の道筋を設計し、集客を整え、気づかぬうちに一日を奪う作業を静かに減らしていきます。',
 			'contact.aside.hi': 'コーチの方でなくても、ひとことの挨拶を歓迎します。届いたメッセージは全部自分で読んで、たいてい数日以内に返事します。',
+			'contact.tools.title': '道具 · side tools',
+			'contact.tools.vcf.label': 'vCard · 連絡先を保存',
+			'contact.tools.vcf.desc': '電話帳や連絡先にそのまま取り込める .vcf。',
+			'contact.tools.ics.label': '予定にコーヒーを入れる',
+			'contact.tools.ics.desc': '私の cal.com のリンクが入った .ics。次の一杯までワンクリック。',
 			'contact.write.lead': '何を教えているか、どこで AI に手間取っているか、教えてください。テンプレートも自動返信もなし、あなたと私だけです。',
 			'contact.field.name': '名前 · Name',
 			'contact.field.email': 'メール · Email',
@@ -711,6 +721,20 @@
 					<a href={SOCIAL_LINKS.github} target="_blank" rel="noopener">GitHub</a>
 					<a href={SOCIAL_LINKS.linkedin} target="_blank" rel="noopener">LinkedIn</a>
 					<a href={SOCIAL_LINKS.twitter} target="_blank" rel="noopener">Twitter</a>
+				</div>
+
+				<div class="contact-tools">
+					<span class="tools-eyebrow">{t('contact.tools.title')}</span>
+					<ul class="tools-list">
+						<li>
+							<a href={asset('/hiro-kuwana.vcf')} download>{t('contact.tools.vcf.label')}</a>
+							<span>{t('contact.tools.vcf.desc')}</span>
+						</li>
+						<li>
+							<a href={asset('/coffee-with-hiro.ics')} download>{t('contact.tools.ics.label')}</a>
+							<span>{t('contact.tools.ics.desc')}</span>
+						</li>
+					</ul>
 				</div>
 			</aside>
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -38,11 +38,11 @@
 			'hero.title.l2': 'that augment',
 			'hero.title.l3': 'humanity',
 			'hero.tagline':
-				"I'm Hiro Kuwana (桑名浩行). Most of my time goes to helping language coaches use AI — quietly, hands-on, so they get hours back each week and keep doing the human part of teaching.",
-			'hero.now': 'Now · AI help for language coaches · 3 seats',
-			'hero.about1.a': 'I work closely with a small number of language coaches each season, mostly Kaiwa coaches building real practice loops with their students. The aim is',
+				"I'm Hiro Kuwana (桑名浩行). Most of my time goes to working directly with the language coaches building on Kaiwa — quietly, hands-on, so they get hours back each week and keep doing the human part of teaching.",
+			'hero.now': 'Now · with the coaches on Kaiwa',
+			'hero.about1.a': 'I work directly with the language coaches building on Kaiwa — designing learner journeys, setting up the AI that handles the tedious parts, and figuring out what good practice looks like between lessons. The aim is',
 			'hero.about1.strong': 'AI that gives you hours back, not another chatbot to babysit.',
-			'hero.about1.b': 'Practical workflows, set up with you, tuned to how you teach.',
+			'hero.about1.b': 'Practical workflows, built with you on Kaiwa, tuned to how you teach.',
 			'hero.about2':
 				'In the time around that, I write here about product, language learning, and the slower questions underneath the work.',
 			'hero.meta.based.k': 'Based',
@@ -79,7 +79,7 @@
 			'contact.titleEm': 'write me, or follow along.',
 			'contact.tab.write': 'Write me · お便り',
 			'contact.tab.follow': 'Follow new posts · 購読',
-			'contact.aside.lead': 'If you teach languages and want to use AI without it eating your evenings, write me. I work hands-on with a few coaches at a time over a few weeks — outreach, lesson prep, the workflows that quietly steal your day.',
+			'contact.aside.lead': 'If you teach languages — or want to — come build with us on Kaiwa. I work alongside our coaches: designing learner journeys, sorting out outreach, and quietly removing the workflows that steal your day.',
 			'contact.aside.hi': 'Not a coach? Still say hello. I read every message by hand and usually reply within a few days.',
 			'contact.write.lead': "Tell me what you teach and where AI keeps getting in the way. No template, no automation, just you and me.",
 			'contact.field.name': 'お名前 · Name',
@@ -119,11 +119,11 @@
 			'hero.title.l2': '',
 			'hero.title.l3': '道具をつくる',
 			'hero.tagline':
-				'桑名浩行 (Hiro Kuwana) です。最近は時間のほとんどを、語学コーチが AI で週に数時間を取り戻せるように、静かに、近くで一緒に整えることに使っています。教える人の、人間らしい仕事を残すために。',
-			'hero.now': '受付中 · 語学コーチの AI 支援 · 三席',
-			'hero.about1.a': '季節ごとに、数名の語学コーチと近くで仕事をしています。多くは Kaiwa で学習の道筋をつくっているコーチです。目指すのは、',
+				'桑名浩行 (Hiro Kuwana) です。最近は時間のほとんどを、Kaiwa で教えている語学コーチと直接、近くで仕事をすることに使っています。AI で週に数時間を取り戻して、教える人の、人間らしい仕事を残すために。',
+			'hero.now': 'いま · Kaiwa のコーチと一緒に',
+			'hero.about1.a': 'Kaiwa で教えている語学コーチと直接、近くで仕事をしています。学習の道筋を設計したり、面倒な部分を AI に任せたり、レッスンの合間の良い練習とは何かを一緒に考えたり。目指すのは、',
 			'hero.about1.strong': 'もう一つチャットボットを抱えるのではなく、時間を取り戻すための AI の使い方。',
-			'hero.about1.b': 'あなたの教え方に合わせて、実用的な仕組みを一緒に組み立てます。',
+			'hero.about1.b': 'あなたの教え方に合わせて、Kaiwa の上で実用的な仕組みを一緒に組み立てます。',
 			'hero.about2': 'その合間に、プロダクトや言語学習、そして仕事の奥にあるゆっくりした問いについて書いています。',
 			'hero.meta.based.k': '拠点',
 			'hero.meta.based.v': '東京 · ニューヨーク',
@@ -159,7 +159,7 @@
 			'contact.titleEm': 'お便りでも、購読でも。',
 			'contact.tab.write': 'お便りを書く · Write',
 			'contact.tab.follow': '更新を購読 · Follow',
-			'contact.aside.lead': '語学を教えていて、AI を使いたいけれど夜の時間まで取られたくない、という方は、ぜひお便りを。同時に数名のコーチと、数週間、近くで一緒に組み立てます。集客、授業準備、気づかぬうちに一日を奪う作業まで。',
+			'contact.aside.lead': '語学を教えている、あるいは教えたいと思っている方は、ぜひ Kaiwa で一緒につくりましょう。コーチと並んで、学習の道筋を設計し、集客を整え、気づかぬうちに一日を奪う作業を静かに減らしていきます。',
 			'contact.aside.hi': 'コーチの方でなくても、ひとことの挨拶を歓迎します。届いたメッセージは全部自分で読んで、たいてい数日以内に返事します。',
 			'contact.write.lead': '何を教えているか、どこで AI に手間取っているか、教えてください。テンプレートも自動返信もなし、あなたと私だけです。',
 			'contact.field.name': '名前 · Name',
@@ -483,10 +483,10 @@
 </script>
 
 <svelte:head>
-	<title>Hiro Kuwana · AI help for language coaches</title>
+	<title>Hiro Kuwana · with the coaches building on Kaiwa</title>
 	<meta
 		name="description"
-		content="Founder-led, hands-on AI help for language coaches — set up the workflows that give you hours back each week. Also notes on product, language learning, and building for the long run."
+		content="Hiro Kuwana works directly with the language coaches building on Kaiwa — designing learner journeys and setting up the AI that gives them hours back each week. Plus notes on product, language learning, and building for the long run."
 	/>
 	<meta name="keywords" content={SITE.keywords.join(', ')} />
 	<meta name="author" content={SITE.author} />
@@ -494,16 +494,16 @@
 	<meta name="googlebot" content="index, follow" />
 	<meta property="og:type" content="profile" />
 	<meta property="og:url" content={SITE.url} />
-	<meta property="og:title" content="Hiro Kuwana · AI help for language coaches" />
-	<meta property="og:description" content="Founder-led, hands-on AI help for language coaches. Plus product notes and slow essays." />
+	<meta property="og:title" content="Hiro Kuwana · with the coaches building on Kaiwa" />
+	<meta property="og:description" content="Hiro Kuwana works directly with the language coaches on Kaiwa. Plus product notes and slow essays." />
 	<meta property="og:image" content={SITE.image} />
 	<meta property="og:locale" content={lang === 'ja' ? 'ja_JP' : 'en_US'} />
 	<meta property="og:locale:alternate" content={lang === 'ja' ? 'en_US' : 'ja_JP'} />
 	<meta property="profile:first_name" content="Hiro" />
 	<meta property="profile:last_name" content="Kuwana" />
 	<meta name="twitter:card" content="summary_large_image" />
-	<meta name="twitter:title" content="Hiro Kuwana · AI help for language coaches" />
-	<meta name="twitter:description" content="Founder-led, hands-on AI help for language coaches. Plus product notes and slow essays by Hiro Kuwana." />
+	<meta name="twitter:title" content="Hiro Kuwana · with the coaches building on Kaiwa" />
+	<meta name="twitter:description" content="Hiro Kuwana works directly with the language coaches on Kaiwa. Plus product notes and slow essays." />
 	<meta name="twitter:image" content={SITE.image} />
 	<link rel="canonical" href={SITE.url} />
 	<link rel="alternate" hreflang="en" href={SITE.url} />

--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -44,7 +44,7 @@
 			? {
 					eyebrow: '自己紹介 · about',
 					title: '少しだけ、自分のこと',
-					lede: '桑名浩行 (Hiro Kuwana) です。日本生まれ、アメリカ育ち。最近は時間のほとんどを、語学コーチが AI で週に数時間を取り戻せるように、静かに、近くで一緒に整えることに使っています。残りの時間は、ここに随筆や手書きの問いとして置いています。',
+					lede: '桑名浩行 (Hiro Kuwana) です。日本生まれ、アメリカ育ち。最近は時間のほとんどを、Kaiwa で教えている語学コーチと直接、近くで仕事をすることに使っています。残りの時間は、ここに随筆や手書きの問いとして置いています。',
 					sub: 'よく聞かれる問い、ゆっくり考えていること、そして雑談。',
 					backHome: 'ホームに戻る',
 					contactPrompt: '話してみたい、書いてみたい、そんな方は',
@@ -53,7 +53,7 @@
 			: {
 					eyebrow: 'about · 自己紹介',
 					title: 'A little about me',
-					lede: "I'm Hiro Kuwana (桑名浩行). Born in Japan, raised in the United States. Most of my time goes to helping language coaches use AI to save hours each week — quiet, hands-on work. The rest of it shows up here as essays, notes, and slow questions.",
+					lede: "I'm Hiro Kuwana (桑名浩行). Born in Japan, raised in the United States. Most of my time goes to working directly with the language coaches building on Kaiwa — quiet, hands-on work. The rest of it shows up here as essays, notes, and slow questions.",
 					sub: "Questions I get asked, things I've been turning over slowly, and a few small ones too.",
 					backHome: 'Back to home',
 					contactPrompt: 'Rather just talk?',

--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -44,7 +44,7 @@
 			? {
 					eyebrow: '自己紹介 · about',
 					title: '少しだけ、自分のこと',
-					lede: '桑名浩行 (Hiro Kuwana) です。日本生まれ、アメリカ育ち。実用的で、ちょっと意地のある AI の道具を、静かに、ていねいに作っています。スクロールするより、考えたい人のために。',
+					lede: '桑名浩行 (Hiro Kuwana) です。日本生まれ、アメリカ育ち。最近は時間のほとんどを、語学コーチが AI で週に数時間を取り戻せるように、静かに、近くで一緒に整えることに使っています。残りの時間は、ここに随筆や手書きの問いとして置いています。',
 					sub: 'よく聞かれる問い、ゆっくり考えていること、そして雑談。',
 					backHome: 'ホームに戻る',
 					contactPrompt: '話してみたい、書いてみたい、そんな方は',
@@ -53,7 +53,7 @@
 			: {
 					eyebrow: 'about · 自己紹介',
 					title: 'A little about me',
-					lede: "I'm Hiro Kuwana (桑名浩行). Born in Japan, raised in the United States. I make practical, opinionated AI utilities, quietly built and carefully made, for people who would rather think than scroll.",
+					lede: "I'm Hiro Kuwana (桑名浩行). Born in Japan, raised in the United States. Most of my time goes to helping language coaches use AI to save hours each week — quiet, hands-on work. The rest of it shows up here as essays, notes, and slow questions.",
 					sub: "Questions I get asked, things I've been turning over slowly, and a few small ones too.",
 					backHome: 'Back to home',
 					contactPrompt: 'Rather just talk?',

--- a/src/style.css
+++ b/src/style.css
@@ -1076,6 +1076,60 @@ main {
 	color: var(--ink);
 }
 
+.contact-tools {
+	margin-top: 2.25rem;
+	padding-top: 1.5rem;
+	border-top: 1px solid var(--rule);
+}
+
+.tools-eyebrow {
+	display: block;
+	margin-bottom: 0.85rem;
+	font-family: var(--f-mono);
+	font-size: 0.6875rem;
+	letter-spacing: 0.12em;
+	text-transform: uppercase;
+	color: var(--ink-mute);
+}
+
+.tools-list {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+	display: flex;
+	flex-direction: column;
+	gap: 0.9rem;
+}
+
+.tools-list li {
+	display: flex;
+	flex-direction: column;
+	gap: 0.2rem;
+}
+
+.tools-list a {
+	font-family: var(--f-display);
+	font-size: 1.0625rem;
+	color: var(--ink);
+	border-bottom: 1px solid var(--rule);
+	align-self: flex-start;
+	padding-bottom: 0.1rem;
+	transition:
+		color 0.25s,
+		border-color 0.25s;
+}
+
+.tools-list a:hover {
+	color: var(--shu);
+	border-bottom-color: var(--shu);
+}
+
+.tools-list span {
+	font-size: 0.875rem;
+	line-height: 1.5;
+	color: var(--ink-mute);
+}
+
 .contact-stack {
 	display: flex;
 	flex-direction: column;

--- a/static/coffee-with-hiro.ics
+++ b/static/coffee-with-hiro.ics
@@ -1,0 +1,25 @@
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Hiro Kuwana//Personal Site//EN
+CALSCALE:GREGORIAN
+METHOD:PUBLISH
+BEGIN:VTIMEZONE
+TZID:Asia/Tokyo
+BEGIN:STANDARD
+DTSTART:19700101T000000
+TZOFFSETFROM:+0900
+TZOFFSETTO:+0900
+TZNAME:JST
+END:STANDARD
+END:VTIMEZONE
+BEGIN:VEVENT
+UID:coffee-with-hiro-kuwana@hirokuwana.com
+DTSTAMP:20260513T000000Z
+DTSTART;TZID=Asia/Tokyo:20260601T140000
+DTEND;TZID=Asia/Tokyo:20260601T141500
+SUMMARY:Coffee with Hiro Kuwana
+URL:https://cal.com/hirokuwana/15min
+LOCATION:https://cal.com/hirokuwana/15min
+DESCRIPTION:A 15-min chat with Hiro. Pick a time that suits you: https://cal.com/hirokuwana/15min . Feel free to drag this event to whenever works.
+END:VEVENT
+END:VCALENDAR

--- a/static/hiro-kuwana.vcf
+++ b/static/hiro-kuwana.vcf
@@ -1,0 +1,14 @@
+BEGIN:VCARD
+VERSION:3.0
+N:Kuwana;Hiroyuki;;;
+FN:Hiro Kuwana
+ORG:Kaiwa
+TITLE:Founder & CEO
+EMAIL;TYPE=INTERNET,WORK,PREF:hiro@trykaiwa.com
+URL;TYPE=WORK:https://www.trykaiwa.com/
+URL;TYPE=HOME:https://hirokuwana.com
+X-SOCIALPROFILE;TYPE=github:https://github.com/hkuwana
+X-SOCIALPROFILE;TYPE=linkedin:https://www.linkedin.com/in/hiroyuki-kuwana/
+X-SOCIALPROFILE;TYPE=twitter:https://twitter.com/hirokuwana
+NOTE:Most of my time goes to working with the language coaches building on Kaiwa.
+END:VCARD

--- a/static/tea-with-hiro.ics
+++ b/static/tea-with-hiro.ics
@@ -13,13 +13,13 @@ TZNAME:JST
 END:STANDARD
 END:VTIMEZONE
 BEGIN:VEVENT
-UID:coffee-with-hiro-kuwana@hirokuwana.com
+UID:tea-with-hiro-kuwana@hirokuwana.com
 DTSTAMP:20260513T000000Z
 DTSTART;TZID=Asia/Tokyo:20260601T140000
 DTEND;TZID=Asia/Tokyo:20260601T141500
-SUMMARY:Coffee with Hiro Kuwana
+SUMMARY:Tea with Hiro Kuwana
 URL:https://cal.com/hirokuwana/15min
 LOCATION:https://cal.com/hirokuwana/15min
-DESCRIPTION:A 15-min chat with Hiro. Pick a time that suits you: https://cal.com/hirokuwana/15min . Feel free to drag this event to whenever works.
+DESCRIPTION:A 15-min tea with Hiro. Pick a time that suits you: https://cal.com/hirokuwana/15min . Feel free to drag this event to whenever works.
 END:VEVENT
 END:VCALENDAR


### PR DESCRIPTION
## Summary
This PR updates the personal portfolio site to reflect a strategic shift in focus from general AI tool development to dedicated work with language coaches building on the Kaiwa platform.

## Key Changes

**Content Updates:**
- Updated hero section messaging across English and Japanese to emphasize direct collaboration with Kaiwa language coaches
- Reframed value proposition from "AI utilities for people who think" to "AI that gives coaches hours back each week"
- Changed availability status from "Open · three seats · this season" to "Now · with the coaches on Kaiwa"
- Updated contact section to specifically target language coaches and educators
- Modified form placeholder text to ask about teaching challenges rather than general projects
- Updated page metadata (title, description, og:tags, twitter:tags) to reflect new focus

**New Features:**
- Added "Side tools" section in contact area with downloadable contact files:
  - vCard (.vcf) for easy contact import
  - Calendar event (.ics) linking to cal.com scheduling
- Created two new static asset files:
  - `hiro-kuwana.vcf` - Standard vCard with contact details and Kaiwa affiliation
  - `tea-with-hiro.ics` - Calendar event for 15-minute tea meetings

**Styling:**
- Added `.contact-tools` section with new styles for tools display
- Implemented `.tools-eyebrow`, `.tools-list`, and related styles for the downloadable tools UI
- Maintained consistent design language with existing portfolio aesthetic

**About Page:**
- Updated Japanese and English lede text to reflect focus on Kaiwa coaching work
- Clarified time allocation between platform work and writing

All changes maintain bilingual support (English/Japanese) and preserve existing design patterns.

https://claude.ai/code/session_018kp8V2kCR6T3WwLV5UwtVz