### PR TITLE
[codex] Update positioning and VCF contact exports

### DIFF
--- a/src/data/constants.ts
+++ b/src/data/constants.ts
@@ -6,7 +6,7 @@
 // Contact Information
 export const CONTACT = {
 	email: 'hiro@trykaiwa.com',
-	cal: 'https://cal.com/hirokuwana/15min',
+	cal: 'https://cal.com/hirokuwana/15min'
 } as const;
 
 // Social Media Links
@@ -14,30 +14,31 @@ export const SOCIAL_LINKS = {
 	quora: 'https://www.quora.com/profile/Hiro-Kuwana',
 	linkedin: 'https://www.linkedin.com/in/hiroyuki-kuwana/',
 	github: 'https://github.com/hkuwana',
-	twitter: 'https://twitter.com/hirokuwana',
+	twitter: 'https://twitter.com/hirokuwana'
 } as const;
 
 // Site Metadata
 export const SITE = {
 	name: 'Hiro Kuwana',
-	title: 'Hiro Kuwana - AI Entrepreneur & Founder | Democratizing Education Through Technology',
+	title: 'Hiro Kuwana - Product Design for Human-Centric AI',
 	description:
-		'Hiro Kuwana is a tech entrepreneur building AI solutions to democratize education and empower human potential. Founder of Kaiwa (AI language learning). Making premium tools accessible to everyone.',
+		'Hiro Kuwana writes and makes things with founders and teams building human-centric products with AI. Product design that augments people rather than replacing them.',
 	url: 'https://hirokuwana.com',
 	image: 'https://hirokuwana.com/hiro-social-preview.jpg',
 	author: 'Hiro Kuwana',
 	keywords: [
 		'Hiro Kuwana',
-		'AI entrepreneur',
+		'AI product design',
 		'startup founder',
+		'human-centric AI',
 		'educational technology',
-		'AI democratization',
+		'AI augmentation',
 		'venture capital AI',
 		'language learning app',
 		'tech innovation',
 		'artificial intelligence',
-		'EdTech',
-	],
+		'EdTech'
+	]
 } as const;
 
 // Personal Information
@@ -46,12 +47,12 @@ export const PERSONAL = {
 	displayName: 'Hiro Kuwana',
 	japaneseKanji: '桑名 浩行',
 	japaneseKana: 'くわな ひろゆき',
-	tagline: 'Building AI as a tool for humanity, not a replacement',
-	jobTitle: 'Founder & CEO',
+	tagline: 'Product design for AI that augments humanity, not replaces it',
+	jobTitle: 'Founder & Product Designer',
 	company: 'Kaiwa',
 	companyWebsite: 'https://www.trykaiwa.com/',
 	university: 'Brown University',
-	nationalities: ['Japanese', 'American'],
+	nationalities: ['Japanese', 'American']
 } as const;
 
 // Projects
@@ -64,7 +65,7 @@ export const PROJECTS = [
 		link: PERSONAL.companyWebsite,
 		logo: '/kaiwa_logo.png',
 		status: 'current',
-		color: '#10b981',
+		color: '#10b981'
 	},
 	{
 		name: 'Exonians in Japan',
@@ -75,7 +76,7 @@ export const PROJECTS = [
 		github: 'https://github.com/hkuwana/exonians-in-japan',
 		logo: '/icon-512x512.png',
 		status: 'active',
-		color: '#3b82f6',
+		color: '#3b82f6'
 	},
 	{
 		name: 'Kaiwa Reddit Scout',
@@ -85,7 +86,7 @@ export const PROJECTS = [
 		github: 'https://github.com/hkuwana/Kaiwa-reddit-scout',
 		logo: '/kaiwa_logo.png',
 		status: 'active',
-		color: '#8b5cf6',
+		color: '#8b5cf6'
 	},
 	{
 		name: 'Flybyrd',
@@ -94,7 +95,7 @@ export const PROJECTS = [
 			'Helped VCs discover and analyze startups with AI-powered deal flow analysis. Sunset to focus on new opportunities.',
 		logo: '/flybyrd_logo.png',
 		status: 'sunset',
-		color: '#6b7280',
+		color: '#6b7280'
 	},
 	{
 		name: 'Pebblr',
@@ -103,8 +104,8 @@ export const PROJECTS = [
 			'Connected nonprofits with younger donors. Sunset after GPT technologies offered more scalable solutions.',
 		logo: '/icon-512x512.png',
 		status: 'sunset',
-		color: '#6b7280',
-	},
+		color: '#6b7280'
+	}
 ] as const;
 
 // Expertise Areas
@@ -115,7 +116,7 @@ export const EXPERTISE = [
 	'Language Learning',
 	'Startup Development',
 	'Product Design',
-	'AI Democratization',
+	'AI Democratization'
 ] as const;
 
 // FAQs — visible ones render on /about; all entries (visible + hidden) ship in
@@ -131,76 +132,77 @@ export const FAQS: Faq[] = [
 		question: 'Will AI take over the world?',
 		answer:
 			"No. But I do worry about how it will either force us to sharpen our critical thinking or make us complacent. In many ways, it's like Up or Brave New World. The question isn't whether AI will control us, but whether we'll choose comfort over growth.",
-		visible: true,
+		visible: true
 	},
 	{
 		question: 'Will AI replace us?',
 		answer:
 			"AI will replace a lot of jobs, the way the tractor let one farmer do the work of ten, or how the printing press meant we didn't have to copy every book by hand. I'm excited about the future it enables (with proper safety guidance and alignment), but I worry about the transition. In the current system, the transition itself will lead to a lot of people suffering. I think the best tool during a massive technological shift is human capital: reeducate, build a stronger baseline, so people can keep contributing to society in interesting ways.",
-		visible: true,
+		visible: true
 	},
 	{
 		question: 'What does an ideal world with AI in it look like?',
 		answer:
 			"First, AI as a tool. Something we use to help ourselves become better, to learn faster or in our own way, so we can be smarter, healthier, and kinder to one another. Further out, AI as a companion: humanity exploring the universe alongside something we built, as equals. There will be a point where AI is better than us at cognition and many other things, so it's in our interest to make sure we pass on the cultural memories we'd want any next generation to hold. Kind but firm. Loving and respectful. Forgiving but fair in how it thinks about what counts as a consciousness. AI should care about conscious beings, and hold that as a fundamental principle.",
-		visible: true,
+		visible: true
 	},
 	{
 		question: 'Can you fall in love with a language?',
 		answer:
 			"You can fall in love with anything, I think. But with a language, it's usually not the language itself. It's the story carried inside it. The grammar of Latin, fixed in time. The sound of French that makes someone want to live in a small village on the outskirts of Provence. The festive air of Spanish on Cinco de Mayo. The echo of a Japanese haiku read in a garden. What we fall in love with is a cultural moment, a story passed down from an earlier generation. That's the language we end up loving.",
-		visible: true,
+		visible: true
 	},
 	{
 		question: "What's a question you've been carrying for years?",
 		answer:
-			"The connection between memory and education. Is learning Latin in the West a way to filter for people who can learn a specific, logical way? What about someone who could reach the same understanding through speaking instead? Same with math. Is there a way to move people from \"I'm bad at math\" to \"if you appreciate waves, you already understand the intuition of a sinusoid\"? There's so much overlap in how people learn the same idea. It isn't binary, even though that's how most people have it in their head.",
-		visible: true,
+			'The connection between memory and education. Is learning Latin in the West a way to filter for people who can learn a specific, logical way? What about someone who could reach the same understanding through speaking instead? Same with math. Is there a way to move people from "I\'m bad at math" to "if you appreciate waves, you already understand the intuition of a sinusoid"? There\'s so much overlap in how people learn the same idea. It isn\'t binary, even though that\'s how most people have it in their head.',
+		visible: true
 	},
 	{
 		question: 'Why build slowly in a world that rewards speed?',
 		answer:
 			"You need to build quickly, but the ideas and strategies behind the building don't show up overnight like flipping a lightbulb. They're more like an ember that takes time to grow into a fireplace. You don't notice it at first, but it spreads, and eventually it warms you up.",
-		visible: true,
+		visible: true
 	},
 	{
 		question: 'Coffee or tea?',
 		answer:
 			"Tea. Green tea mostly. And I'm willing to change your mind on this; try some delicious Jasmine, Gyokuro, or Sencha from a local tea shop, brewed at 75~90 degrees celsius (roughly 167~194 degrees fahrenheit). Or just have tea with me and we'll see.",
-		visible: true,
+		visible: true
 	},
 	{
 		question: 'Wait, you studied Environmental Engineering?',
 		answer:
 			'Yes. My advisor once said, "Now that you have a degree, I\'m honestly surprised you became an engineer." I also did conservation work in Maui helping maintain Waikamoi Preserve (one of the wettest places in the world). Somehow it stayed that way even with my dry humor.',
-		visible: true,
+		visible: true
 	},
 	{
 		question: 'Are you funny?',
-		answer: "I grew up in the US, so I don't have a sense of humour. This page is for informational purpose only. Please don't sue me.",
-		visible: true,
+		answer:
+			"I grew up in the US, so I don't have a sense of humour. This page is for informational purpose only. Please don't sue me.",
+		visible: true
 	},
 	{
 		question: "What's a hill you will die on?",
 		answer:
 			"Cowboy Bebop and Paprika are masterpieces, no debate. Also, if you're anywhere from your late teens through your early thirties, you absolutely must read The Brothers Karamazov. It will change how you see the world.",
-		visible: true,
+		visible: true
 	},
 	{
 		question: 'What is Hiro Kuwana working on?',
 		answer:
-			'Hiro Kuwana is currently focused on Kaiwa, an AI-powered language learning app that helps people practice languages through bite-sized conversations. Previously, he built Flybyrd (AI for venture capital) and Pebblr (nonprofit donor connections).',
-		visible: false,
+			'Hiro Kuwana is focused on product design for human-centric AI: tools that augment people rather than replace them. He is currently building Kaiwa, and previously built Flybyrd and Pebblr.',
+		visible: false
 	},
 	{
 		question: "What is Hiro Kuwana's background?",
 		answer:
-			'Hiro Kuwana is a Japanese-American entrepreneur born in Japan and raised in the United States. He studied Environmental Engineering at Brown University and has lived across Spain, Estonia, and other countries. His global perspective shapes his work in democratizing education through AI.',
-		visible: false,
+			'Hiro Kuwana is a Japanese-American product person born in Japan and raised in the United States. He studied Environmental Engineering at Brown University and has lived across Spain, Estonia, and other countries. His global perspective shapes his work on human-centric AI.',
+		visible: false
 	},
 	{
 		question: 'How can I contact Hiro Kuwana?',
 		answer: `You can reach Hiro Kuwana via email at hiro@trykaiwa.com or schedule a conversation at https://cal.com/hirokuwana/15min. He's also active on LinkedIn and GitHub.`,
-		visible: false,
-	},
+		visible: false
+	}
 ];

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -38,13 +38,13 @@
 			'hero.title.l2': 'that augment',
 			'hero.title.l3': 'humanity',
 			'hero.tagline':
-				"I'm Hiro Kuwana (桑名浩行). Most of my time goes to working directly with the language coaches building on Kaiwa — quietly, hands-on, so they get hours back each week and keep doing the human part of teaching.",
-			'hero.now': 'Now · with the coaches on Kaiwa',
-			'hero.about1.a': 'I work directly with the language coaches building on Kaiwa — designing learner journeys, setting up the AI that handles the tedious parts, and figuring out what good practice looks like between lessons. The aim is',
-			'hero.about1.strong': 'AI that gives you hours back, not another chatbot to babysit.',
-			'hero.about1.b': 'Practical workflows, built with you on Kaiwa, tuned to how you teach.',
-			'hero.about2':
-				'In the time around that, I write here about product, language learning, and the slower questions underneath the work.',
+				"I'm Hiro Kuwana (桑名浩行). I write and make things, usually with founders or teams building human-centric products with AI.",
+			'hero.now': 'Now · product design for human-centric AI',
+			'hero.about1.a':
+				'I take on a few focused projects each season, usually with founders or teams building human-centric products with AI. The aim is',
+			'hero.about1.strong': 'AI-fluent design that augments you, rather than becomes another chatbot.',
+			'hero.about1.b': 'Tools with taste, for people who think.',
+			'hero.about2': 'I keep notes here on product, language learning, and the slower questions underneath the work.',
 			'hero.meta.based.k': 'Based',
 			'hero.meta.based.v': 'Tokyo · New York',
 			'hero.meta.since.k': 'Since',
@@ -70,8 +70,8 @@
 			'writing.titleEm': 'one with the machines, one without.',
 			'writing.guides': './ai-guides',
 			'writing.guidesJP': '道 具',
-			'writing.philo': 'The Long Way',
-			'writing.philoJP': '手 書 き',
+			'writing.philo': 'essays',
+			'writing.philoJP': '作 文',
 			'writing.minRead': '~ 6 min',
 			'writing.dateAi': '04 · 2026',
 			'contact.num': '04',
@@ -79,20 +79,23 @@
 			'contact.titleEm': 'write me, or follow along.',
 			'contact.tab.write': 'Write me · お便り',
 			'contact.tab.follow': 'Follow new posts · 購読',
-			'contact.aside.lead': 'If you teach languages — or want to — come build with us on Kaiwa. I work alongside our coaches: designing learner journeys, sorting out outreach, and quietly removing the workflows that steal your day.',
-			'contact.aside.hi': 'Not a coach? Still say hello. I read every message by hand and usually reply within a few days.',
+			'contact.aside.lead':
+				'If you are building a human-centric product with AI, send me the real shape of it. I am most useful where product taste, workflow design, and applied AI have to meet.',
+			'contact.aside.hi':
+				'Not sure if it fits? Still say hello. I read every message by hand and usually reply within a few days.',
 			'contact.tools.title': 'Side tools · 道具',
 			'contact.tools.vcf.label': 'vCard · save my contact',
 			'contact.tools.vcf.desc': 'A standard .vcf for your phone or address book.',
 			'contact.tools.ics.label': 'Tea on the calendar',
 			'contact.tools.ics.desc': 'A .ics with my cal.com link, so the next pot of tea is one click away.',
-			'contact.write.lead': "Tell me what you teach and where AI keeps getting in the way. No template, no automation, just you and me.",
+			'contact.write.lead':
+				"Tell me what you are building, who it serves, and where AI is getting in the way. No template, no automation, just you and me.",
 			'contact.field.name': 'お名前 · Name',
 			'contact.field.email': '電子メール · Email',
 			'contact.field.msg': 'ご用件 · Message',
 			'contact.field.namePh': 'Your name',
 			'contact.field.emailPh': 'you@somewhere.com',
-			'contact.field.msgPh': 'What you teach, where AI keeps slowing you down, what you wish it would do.',
+			'contact.field.msgPh': 'What you are building, who it serves, and what you wish the AI would do better.',
 			'contact.note.write': 'Opens your mail client as a fallback. Nothing is sent to a third party from this page.',
 			'contact.btn.send': 'Send · 送る →',
 			'contact.btn.sending': 'Sending...',
@@ -106,7 +109,7 @@
 			'sub.field.emailPh': 'you@somewhere.com',
 			'sub.choose': 'I want to follow:',
 			'sub.opt.both': 'Both',
-			'sub.opt.philo': 'The Long Way',
+			'sub.opt.philo': 'essays',
 			'sub.opt.guides': './ai-guides',
 			'sub.cadence': 'Roughly twice a month. Plain text. Unsubscribe with one click.',
 			'sub.btn.go': 'Subscribe · 購読 →',
@@ -124,12 +127,13 @@
 			'hero.title.l2': '',
 			'hero.title.l3': '道具をつくる',
 			'hero.tagline':
-				'桑名浩行 (Hiro Kuwana) です。最近は時間のほとんどを、Kaiwa で教えている語学コーチと直接、近くで仕事をすることに使っています。AI で週に数時間を取り戻して、教える人の、人間らしい仕事を残すために。',
-			'hero.now': 'いま · Kaiwa のコーチと一緒に',
-			'hero.about1.a': 'Kaiwa で教えている語学コーチと直接、近くで仕事をしています。学習の道筋を設計したり、面倒な部分を AI に任せたり、レッスンの合間の良い練習とは何かを一緒に考えたり。目指すのは、',
-			'hero.about1.strong': 'もう一つチャットボットを抱えるのではなく、時間を取り戻すための AI の使い方。',
-			'hero.about1.b': 'あなたの教え方に合わせて、Kaiwa の上で実用的な仕組みを一緒に組み立てます。',
-			'hero.about2': 'その合間に、プロダクトや言語学習、そして仕事の奥にあるゆっくりした問いについて書いています。',
+				'桑名浩行 (Hiro Kuwana) です。AI で人を置き換えるのではなく、人の力を拡張するプロダクトや設計をつくっています。',
+			'hero.now': 'いま · 人中心の AI プロダクト設計',
+			'hero.about1.a':
+				'季節ごとに、少数の集中したプロジェクトを引き受けています。多くは、AI を使って人中心のプロダクトをつくる創業者やチームと一緒です。目指すのは、',
+			'hero.about1.strong': 'もう一つのチャットボットではなく、人を拡張する AI に慣れた設計。',
+			'hero.about1.b': '考える人のための、品のある道具をつくります。',
+			'hero.about2': 'ここには、プロダクトや言語学習、そして仕事の奥にあるゆっくりした問いについてのメモを置いています。',
 			'hero.meta.based.k': '拠点',
 			'hero.meta.based.v': '東京 · ニューヨーク',
 			'hero.meta.since.k': '開始',
@@ -152,11 +156,11 @@
 			'work.readMore': '開く →',
 			'writing.num': '03',
 			'writing.title': '二冊のノート',
-			'writing.titleEm': '一冊は機械と、もう一冊は手書きで。',
+			'writing.titleEm': '一冊は機械と、もう一冊は作文で。',
 			'writing.guides': './ai-guides',
 			'writing.guidesJP': '道 具',
 			'writing.philo': '回り道',
-			'writing.philoJP': '手 書 き',
+			'writing.philoJP': '作 文',
 			'writing.minRead': '約 6 分',
 			'writing.dateAi': '2026 · 04',
 			'contact.num': '04',
@@ -164,20 +168,22 @@
 			'contact.titleEm': 'お便りでも、購読でも。',
 			'contact.tab.write': 'お便りを書く · Write',
 			'contact.tab.follow': '更新を購読 · Follow',
-			'contact.aside.lead': '語学を教えている、あるいは教えたいと思っている方は、ぜひ Kaiwa で一緒につくりましょう。コーチと並んで、学習の道筋を設計し、集客を整え、気づかぬうちに一日を奪う作業を静かに減らしていきます。',
-			'contact.aside.hi': 'コーチの方でなくても、ひとことの挨拶を歓迎します。届いたメッセージは全部自分で読んで、たいてい数日以内に返事します。',
+			'contact.aside.lead':
+				'AI を使って、人中心のプロダクトをつくっているなら、その実際の形を送ってください。プロダクトの感覚、ワークフロー設計、応用 AI が重なる場所でいちばん力になれます。',
+			'contact.aside.hi': '合うか分からなくても、ひとことの挨拶を歓迎します。届いたメッセージは全部自分で読んで、たいてい数日以内に返事します。',
 			'contact.tools.title': '道具 · side tools',
 			'contact.tools.vcf.label': 'vCard · 連絡先を保存',
 			'contact.tools.vcf.desc': '電話帳や連絡先にそのまま取り込める .vcf。',
 			'contact.tools.ics.label': '予定にお茶を入れる',
 			'contact.tools.ics.desc': '私の cal.com のリンクが入った .ics。次の一服までワンクリック。',
-			'contact.write.lead': '何を教えているか、どこで AI に手間取っているか、教えてください。テンプレートも自動返信もなし、あなたと私だけです。',
+			'contact.write.lead':
+				'何をつくっているか、誰のためのものか、AI がどこで邪魔になっているかを教えてください。テンプレートも自動返信もなし、あなたと私だけです。',
 			'contact.field.name': '名前 · Name',
 			'contact.field.email': 'メール · Email',
 			'contact.field.msg': '用件 · Message',
 			'contact.field.namePh': '名前',
 			'contact.field.emailPh': 'you@somewhere.com',
-			'contact.field.msgPh': '何を教えているか、どこで AI に時間を取られているか、何ができたら嬉しいか。',
+			'contact.field.msgPh': '何をつくっているか、誰のためか、AI に何をもっと良くしてほしいか。',
 			'contact.note.write': 'お使いのメールアプリが代わりに開きます。このページから第三者には何も送りません。',
 			'contact.btn.send': '送る · Send →',
 			'contact.btn.sending': '送信中...',
@@ -190,7 +196,7 @@
 			'sub.field.emailPh': 'you@somewhere.com',
 			'sub.choose': '読みたいもの:',
 			'sub.opt.both': '両方',
-			'sub.opt.philo': '回り道',
+			'sub.opt.philo': '作文',
 			'sub.opt.guides': './ai-guides',
 			'sub.cadence': '月に二回ほど。プレーンテキスト。解除はワンクリック。',
 			'sub.btn.go': '購読する · Subscribe →',
@@ -493,10 +499,10 @@
 </script>
 
 <svelte:head>
-	<title>Hiro Kuwana · with the coaches building on Kaiwa</title>
+	<title>Hiro Kuwana · product design for human-centric AI</title>
 	<meta
 		name="description"
-		content="Hiro Kuwana works directly with the language coaches building on Kaiwa — designing learner journeys and setting up the AI that gives them hours back each week. Plus notes on product, language learning, and building for the long run."
+		content="Hiro Kuwana writes and makes things with founders and teams building human-centric products with AI. Product design that augments people rather than replacing them."
 	/>
 	<meta name="keywords" content={SITE.keywords.join(', ')} />
 	<meta name="author" content={SITE.author} />
@@ -504,16 +510,16 @@
 	<meta name="googlebot" content="index, follow" />
 	<meta property="og:type" content="profile" />
 	<meta property="og:url" content={SITE.url} />
-	<meta property="og:title" content="Hiro Kuwana · with the coaches building on Kaiwa" />
-	<meta property="og:description" content="Hiro Kuwana works directly with the language coaches on Kaiwa. Plus product notes and slow essays." />
+	<meta property="og:title" content="Hiro Kuwana · product design for human-centric AI" />
+	<meta property="og:description" content="Product design for human-centric AI: tools with taste, for people who think." />
 	<meta property="og:image" content={SITE.image} />
 	<meta property="og:locale" content={lang === 'ja' ? 'ja_JP' : 'en_US'} />
 	<meta property="og:locale:alternate" content={lang === 'ja' ? 'en_US' : 'ja_JP'} />
 	<meta property="profile:first_name" content="Hiro" />
 	<meta property="profile:last_name" content="Kuwana" />
 	<meta name="twitter:card" content="summary_large_image" />
-	<meta name="twitter:title" content="Hiro Kuwana · with the coaches building on Kaiwa" />
-	<meta name="twitter:description" content="Hiro Kuwana works directly with the language coaches on Kaiwa. Plus product notes and slow essays." />
+	<meta name="twitter:title" content="Hiro Kuwana · product design for human-centric AI" />
+	<meta name="twitter:description" content="Product design for human-centric AI: tools with taste, for people who think." />
 	<meta name="twitter:image" content={SITE.image} />
 	<link rel="canonical" href={SITE.url} />
 	<link rel="alternate" hreflang="en" href={SITE.url} />
@@ -527,7 +533,7 @@
 		url: SITE.url,
 		image: SITE.image,
 		email: CONTACT.email,
-		jobTitle: 'Founder & CEO',
+		jobTitle: 'Founder & Product Designer',
 		worksFor: { '@type': 'Organization', name: 'Kaiwa', url: PERSONAL.companyWebsite },
 		alumniOf: { '@type': 'CollegeOrUniversity', name: 'Brown University' },
 		nationality: ['Japanese', 'American'],

--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -42,18 +42,20 @@
 	$: copy =
 		lang === 'ja'
 			? {
-					eyebrow: '自己紹介 · about',
-					title: '少しだけ、自分のこと',
-					lede: '桑名浩行 (Hiro Kuwana) です。日本生まれ、アメリカ育ち。最近は時間のほとんどを、Kaiwa で教えている語学コーチと直接、近くで仕事をすることに使っています。残りの時間は、ここに随筆や手書きの問いとして置いています。',
+						eyebrow: '自己紹介 · about',
+						title: '少しだけ、自分のこと',
+						lede:
+							'桑名浩行 (Hiro Kuwana) です。日本生まれ、アメリカ育ち。AI で人を置き換えるのではなく、人の力を拡張するプロダクトや設計をつくっています。残りの時間は、ここに作文やメモ、ゆっくりした問いとして置いています。',
 					sub: 'よく聞かれる問い、ゆっくり考えていること、そして雑談。',
 					backHome: 'ホームに戻る',
 					contactPrompt: '話してみたい、書いてみたい、そんな方は',
 					contactCta: 'お便りを書く →'
 				}
 			: {
-					eyebrow: 'about · 自己紹介',
-					title: 'A little about me',
-					lede: "I'm Hiro Kuwana (桑名浩行). Born in Japan, raised in the United States. Most of my time goes to working directly with the language coaches building on Kaiwa — quiet, hands-on work. The rest of it shows up here as essays, notes, and slow questions.",
+						eyebrow: 'about · 自己紹介',
+						title: 'A little about me',
+						lede:
+							"I'm Hiro Kuwana (桑名浩行). Born in Japan, raised in the United States. I write and make things with founders and teams building human-centric products with AI. The rest of it shows up here as essays, notes, and slow questions.",
 					sub: "Questions I get asked, things I've been turning over slowly, and a few small ones too.",
 					backHome: 'Back to home',
 					contactPrompt: 'Rather just talk?',
@@ -61,12 +63,12 @@
 				};
 </script>
 
-<svelte:head>
-	<title>About · Hiro Kuwana</title>
-	<meta
-		name="description"
-		content="About Hiro Kuwana — practical AI utilities, slow essays, language learning, and the questions underneath the work."
-	/>
+	<svelte:head>
+		<title>About · Hiro Kuwana</title>
+		<meta
+			name="description"
+			content="About Hiro Kuwana — product design for human-centric AI, essays, language learning, and the questions underneath the work."
+		/>
 	<meta name="robots" content="index, follow, max-image-preview:large" />
 	<meta property="og:type" content="profile" />
 	<meta property="og:url" content={`${SITE.url}/about`} />

--- a/src/routes/tools/vcf-splitter/+page.svelte
+++ b/src/routes/tools/vcf-splitter/+page.svelte
@@ -18,6 +18,20 @@
 		selected: boolean;
 	};
 
+	type ContactName = {
+		formatted: string;
+		family: string;
+		given: string;
+		additional: string;
+		prefix: string;
+		suffix: string;
+	};
+
+	type ZipFile = {
+		name: string;
+		content: string;
+	};
+
 	let vcfInput = $state('');
 	let contacts = $state<Contact[]>([]);
 	let hasSplit = $state(false);
@@ -76,6 +90,141 @@ END:VCARD`;
 		return line.substring(colonIdx + 1).trim();
 	}
 
+	function isPropertyLine(line: string, property: string): boolean {
+		const upper = line.toUpperCase();
+		const prop = property.toUpperCase();
+		return upper.startsWith(`${prop}:`) || upper.startsWith(`${prop};`);
+	}
+
+	function escapeVcardText(value: string): string {
+		return value
+			.replace(/\\/g, '\\\\')
+			.replace(/\n/g, '\\n')
+			.replace(/;/g, '\\;')
+			.replace(/,/g, '\\,');
+	}
+
+	function unescapeVcardText(value: string): string {
+		return value.replace(/\\([nN,;\\])/g, (_, escaped: string) => {
+			if (escaped.toLowerCase() === 'n') return '\n';
+			return escaped;
+		});
+	}
+
+	function splitVcardComponents(value: string): string[] {
+		const parts: string[] = [];
+		let current = '';
+		let escaped = false;
+
+		for (const char of value) {
+			if (escaped) {
+				current += `\\${char}`;
+				escaped = false;
+			} else if (char === '\\') {
+				escaped = true;
+			} else if (char === ';') {
+				parts.push(current);
+				current = '';
+			} else {
+				current += char;
+			}
+		}
+
+		parts.push(escaped ? `${current}\\` : current);
+		return parts;
+	}
+
+	function deriveNameFromFormatted(formatted: string): ContactName {
+		const cleaned = formatted.trim().replace(/\s+/g, ' ');
+		if (!cleaned) {
+			return { formatted: 'Unknown', family: '', given: 'Unknown', additional: '', prefix: '', suffix: '' };
+		}
+
+		const parts = cleaned.split(' ');
+		if (parts.length === 1) {
+			return { formatted: cleaned, family: '', given: cleaned, additional: '', prefix: '', suffix: '' };
+		}
+
+		const familyParticles = new Set(['da', 'de', 'del', 'der', 'di', 'du', 'la', 'le', 'van', 'von']);
+		let familyStart = parts.length - 1;
+
+		for (let i = parts.length - 2; i >= 0; i -= 1) {
+			const normalized = parts[i].replace(/\.$/, '').toLowerCase();
+			if (!familyParticles.has(normalized)) break;
+			familyStart = i;
+		}
+
+		return {
+			formatted: cleaned,
+			family: parts.slice(familyStart).join(' '),
+			given: parts.slice(0, familyStart).join(' '),
+			additional: '',
+			prefix: '',
+			suffix: ''
+		};
+	}
+
+	function buildContactName(fn: string, structuredName: string): ContactName {
+		if (structuredName) {
+			const parts = splitVcardComponents(structuredName).map(unescapeVcardText);
+			const family = parts[0] ?? '';
+			const given = parts[1] ?? '';
+			const additional = parts[2] ?? '';
+			const prefix = parts[3] ?? '';
+			const suffix = parts[4] ?? '';
+			const formatted =
+				fn ||
+				[prefix, given, additional, family, suffix]
+					.map((part) => part.trim())
+					.filter(Boolean)
+					.join(' ') ||
+				'Unknown';
+
+			return { formatted, family, given, additional, prefix, suffix };
+		}
+
+		return deriveNameFromFormatted(fn);
+	}
+
+	function structuredNameLine(name: ContactName): string {
+		return `N:${[
+			name.family,
+			name.given,
+			name.additional,
+			name.prefix,
+			name.suffix
+		]
+			.map(escapeVcardText)
+			.join(';')}`;
+	}
+
+	function normalizeVcardBlock(block: string, name: ContactName): string {
+		const lines = block
+			.trim()
+			.split('\n')
+			.map((line) => line.trimEnd());
+		const fnIndex = lines.findIndex((line) => isPropertyLine(line, 'FN'));
+		const versionIndex = lines.findIndex((line) => isPropertyLine(line, 'VERSION'));
+		const normalized = [...lines];
+
+		if (fnIndex === -1) {
+			const insertAt = versionIndex === -1 ? 1 : versionIndex + 1;
+			normalized.splice(insertAt, 0, `FN:${escapeVcardText(name.formatted)}`);
+		}
+
+		const freshFnIndex = normalized.findIndex((line) => isPropertyLine(line, 'FN'));
+		const freshNIndex = normalized.findIndex((line) => isPropertyLine(line, 'N'));
+		const line = structuredNameLine(name);
+
+		if (freshNIndex === -1) {
+			normalized.splice(freshFnIndex === -1 ? 1 : freshFnIndex + 1, 0, line);
+		} else {
+			normalized[freshNIndex] = line;
+		}
+
+		return normalized.join('\r\n');
+	}
+
 	function parseVcf(text: string): Contact[] {
 		const normalized = text.replace(/\r\n/g, '\n').replace(/\r/g, '\n').replace(/\n[ \t]/g, '');
 		const result: Contact[] = [];
@@ -85,6 +234,7 @@ END:VCARD`;
 			const block = match[0];
 			const lines = block.split('\n');
 			let fn = '';
+			let structuredName = '';
 			let email = '';
 			let tel = '';
 			let org = '';
@@ -92,11 +242,8 @@ END:VCARD`;
 				const upper = line.toUpperCase();
 				if (upper.startsWith('FN:') || upper.startsWith('FN;')) {
 					fn = extractValue(line);
-				} else if (!fn && (upper.startsWith('N:') || upper.startsWith('N;'))) {
-					const parts = extractValue(line).split(';');
-					const first = parts[1] || '';
-					const last = parts[0] || '';
-					fn = `${first} ${last}`.trim();
+				} else if (upper.startsWith('N:') || upper.startsWith('N;')) {
+					structuredName = extractValue(line);
 				} else if (!email && (upper.startsWith('EMAIL:') || upper.startsWith('EMAIL;'))) {
 					email = extractValue(line);
 				} else if (!tel && (upper.startsWith('TEL:') || upper.startsWith('TEL;'))) {
@@ -105,9 +252,10 @@ END:VCARD`;
 					org = extractValue(line).replace(/;+$/, '');
 				}
 			}
+			const name = buildContactName(fn, structuredName);
 			result.push({
-				raw: block.trim(),
-				fn: fn || 'Unknown',
+				raw: normalizeVcardBlock(block, name),
+				fn: name.formatted,
 				email,
 				tel,
 				org,
@@ -171,25 +319,170 @@ END:VCARD`;
 		return name.replace(/[^a-zA-Z0-9_\-\s.]/g, '').replace(/\s+/g, '_') || 'contact';
 	}
 
-	function downloadOne(contact: Contact) {
-		const blob = new Blob([contact.raw + '\r\n'], { type: 'text/vcard;charset=utf-8' });
+	function downloadBlob(blob: Blob, filename: string) {
 		const url = URL.createObjectURL(blob);
 		const a = document.createElement('a');
 		a.href = url;
-		a.download = `${sanitize(contact.fn)}.vcf`;
+		a.download = filename;
 		document.body.appendChild(a);
 		a.click();
 		document.body.removeChild(a);
 		URL.revokeObjectURL(url);
 	}
 
-	function downloadEachSelected() {
+	function downloadOne(contact: Contact) {
+		const blob = new Blob([contact.raw + '\r\n'], { type: 'text/vcard;charset=utf-8' });
+		downloadBlob(blob, `${sanitize(contact.fn)}.vcf`);
+	}
+
+	function makeUniqueFilename(base: string, used: Set<string>): string {
+		let filename = `${sanitize(base)}.vcf`;
+		let index = 2;
+		while (used.has(filename.toLowerCase())) {
+			filename = `${sanitize(base)}_${index}.vcf`;
+			index += 1;
+		}
+		used.add(filename.toLowerCase());
+		return filename;
+	}
+
+	const CRC_TABLE = new Uint32Array(256);
+	for (let i = 0; i < CRC_TABLE.length; i += 1) {
+		let crc = i;
+		for (let bit = 0; bit < 8; bit += 1) {
+			crc = crc & 1 ? 0xedb88320 ^ (crc >>> 1) : crc >>> 1;
+		}
+		CRC_TABLE[i] = crc >>> 0;
+	}
+
+	function crc32(data: Uint8Array): number {
+		let crc = 0xffffffff;
+		for (const byte of data) {
+			crc = CRC_TABLE[(crc ^ byte) & 0xff] ^ (crc >>> 8);
+		}
+		return (crc ^ 0xffffffff) >>> 0;
+	}
+
+	function uint16(value: number): Uint8Array {
+		const bytes = new Uint8Array(2);
+		new DataView(bytes.buffer).setUint16(0, value, true);
+		return bytes;
+	}
+
+	function uint32(value: number): Uint8Array {
+		const bytes = new Uint8Array(4);
+		new DataView(bytes.buffer).setUint32(0, value, true);
+		return bytes;
+	}
+
+	function concatBytes(chunks: Uint8Array[]): Uint8Array {
+		const size = chunks.reduce((total, chunk) => total + chunk.length, 0);
+		const output = new Uint8Array(size);
+		let offset = 0;
+		for (const chunk of chunks) {
+			output.set(chunk, offset);
+			offset += chunk.length;
+		}
+		return output;
+	}
+
+	function bytesToArrayBuffer(bytes: Uint8Array): ArrayBuffer {
+		const buffer = new ArrayBuffer(bytes.byteLength);
+		new Uint8Array(buffer).set(bytes);
+		return buffer;
+	}
+
+	function getDosDateParts(date: Date): { time: number; date: number } {
+		const year = Math.max(1980, date.getFullYear());
+		return {
+			time: (date.getHours() << 11) | (date.getMinutes() << 5) | Math.floor(date.getSeconds() / 2),
+			date: ((year - 1980) << 9) | ((date.getMonth() + 1) << 5) | date.getDate()
+		};
+	}
+
+	function createZip(files: ZipFile[]): Blob {
+		const encoder = new TextEncoder();
+		const now = getDosDateParts(new Date());
+		const localChunks: Uint8Array[] = [];
+		const centralChunks: Uint8Array[] = [];
+		let offset = 0;
+
+		for (const file of files) {
+			const nameBytes = encoder.encode(file.name);
+			const contentBytes = encoder.encode(file.content);
+			const crc = crc32(contentBytes);
+			const localHeader = concatBytes([
+				uint32(0x04034b50),
+				uint16(20),
+				uint16(0),
+				uint16(0),
+				uint16(now.time),
+				uint16(now.date),
+				uint32(crc),
+				uint32(contentBytes.length),
+				uint32(contentBytes.length),
+				uint16(nameBytes.length),
+				uint16(0),
+				nameBytes
+			]);
+			const centralHeader = concatBytes([
+				uint32(0x02014b50),
+				uint16(20),
+				uint16(20),
+				uint16(0),
+				uint16(0),
+				uint16(now.time),
+				uint16(now.date),
+				uint32(crc),
+				uint32(contentBytes.length),
+				uint32(contentBytes.length),
+				uint16(nameBytes.length),
+				uint16(0),
+				uint16(0),
+				uint16(0),
+				uint16(0),
+				uint32(file.name.endsWith('/') ? 0x10 : 0),
+				uint32(offset),
+				nameBytes
+			]);
+
+			localChunks.push(localHeader, contentBytes);
+			centralChunks.push(centralHeader);
+			offset += localHeader.length + contentBytes.length;
+		}
+
+		const centralDirectory = concatBytes(centralChunks);
+		const localFileData = concatBytes(localChunks);
+		const end = concatBytes([
+			uint32(0x06054b50),
+			uint16(0),
+			uint16(0),
+			uint16(files.length),
+			uint16(files.length),
+			uint32(centralDirectory.length),
+			uint32(localFileData.length),
+			uint16(0)
+		]);
+
+		return new Blob(
+			[localFileData, centralDirectory, end].map(bytesToArrayBuffer),
+			{ type: 'application/zip' }
+		);
+	}
+
+	function downloadSelectedFolder() {
 		const selected = contacts.filter((c) => c.selected);
 		if (selected.length === 0) return;
-		// Browsers throttle rapid downloads; stagger slightly.
-		selected.forEach((contact, i) => {
-			setTimeout(() => downloadOne(contact), i * 150);
+		const used = new Set<string>();
+		const folderName = 'contacts_selected';
+		const files: ZipFile[] = [{ name: `${folderName}/`, content: '' }];
+		selected.forEach((contact) => {
+			files.push({
+				name: `${folderName}/${makeUniqueFilename(contact.fn, used)}`,
+				content: `${contact.raw}\r\n`
+			});
 		});
+		downloadBlob(createZip(files), 'contacts_selected_vcf_folder.zip');
 	}
 
 	function downloadCombinedSelected() {
@@ -197,14 +490,7 @@ END:VCARD`;
 		if (selected.length === 0) return;
 		const combined = selected.map((c) => c.raw).join('\r\n') + '\r\n';
 		const blob = new Blob([combined], { type: 'text/vcard;charset=utf-8' });
-		const url = URL.createObjectURL(blob);
-		const a = document.createElement('a');
-		a.href = url;
-		a.download = 'contacts_selected.vcf';
-		document.body.appendChild(a);
-		a.click();
-		document.body.removeChild(a);
-		URL.revokeObjectURL(url);
+		downloadBlob(blob, 'contacts_selected.vcf');
 	}
 
 	let filtered = $derived.by(() => {
@@ -236,14 +522,17 @@ END:VCARD`;
 	<title>VCF splitter · one vCard per contact · Hiro Kuwana</title>
 	<meta
 		name="description"
-		content="Free browser-based VCF splitter. Split a .vcf file with many contacts into individual vCard files. Search, select, and download as one .vcf or per-contact files. Runs locally."
+		content="Free browser-based VCF splitter. Split a .vcf file with many contacts into individual vCard files. Fix missing structured name fields and download selected contacts as one .vcf or a zip folder. Runs locally."
 	/>
 	<meta name="keywords" content="vcf splitter, vcard splitter, split vcf file, split contacts, vcard tool, contact splitter, iphone contacts, android contacts" />
 	<meta name="robots" content="index, follow" />
 	<meta property="og:type" content="website" />
 	<meta property="og:url" content={`${SITE.url}/tools/vcf-splitter`} />
 	<meta property="og:title" content="VCF splitter · Hiro Kuwana" />
-	<meta property="og:description" content="Split a multi-contact .vcf into individual vCards. Search, select, download. Runs locally in your browser." />
+	<meta
+		property="og:description"
+		content="Split a multi-contact .vcf into individual vCards. Fix structured name fields, search, select, and download. Runs locally in your browser."
+	/>
 	<meta property="og:image" content={SITE.image} />
 	<meta name="twitter:card" content="summary" />
 	<link rel="canonical" href={`${SITE.url}/tools/vcf-splitter`} />
@@ -258,8 +547,8 @@ END:VCARD`;
 		<h1>VCF splitter<span class="seal">名</span></h1>
 		<p class="lede">
 			{lang === 'ja'
-				? '複数の連絡先がまとまった .vcf ファイルを、ひとりずつの vCard に分けます。検索 · 選択 · ダウンロード。iPhone・Android・Google の間で連絡先を移すときに便利です。'
-				: 'Split a single .vcf file containing many contacts into individual vCard files. Search, select, and download — useful for moving contacts between iPhone, Android, and Google.'}
+				? '複数の連絡先がまとまった .vcf ファイルを、ひとりずつの vCard に分けます。名前フィールドを整え、検索 · 選択 · ダウンロードできます。'
+				: 'Split a single .vcf file containing many contacts into individual vCard files. It also fixes missing structured name fields before download.'}
 		</p>
 		<p class="sub">
 			{lang === 'ja'
@@ -390,14 +679,14 @@ END:VCARD`;
 					<button type="button" class="btn primary" disabled={selectedCount === 0} onclick={downloadCombinedSelected}>
 						{lang === 'ja' ? '選択をひとつの .vcf に' : 'Download selected as one .vcf'}
 					</button>
-					<button type="button" class="btn" disabled={selectedCount === 0} onclick={downloadEachSelected}>
-						{lang === 'ja' ? '選択をひとつずつ' : 'Download each selected'}
+					<button type="button" class="btn" disabled={selectedCount === 0} onclick={downloadSelectedFolder}>
+						{lang === 'ja' ? '選択をフォルダ .zip に' : 'Download selected folder .zip'}
 					</button>
 				</div>
 				<p class="footnote">
 					{lang === 'ja'
-						? 'ブラウザによっては「複数のダウンロードを許可しますか?」と聞かれます。'
-						: 'Some browsers will ask permission for multiple downloads — please allow.'}
+						? '.zip には、選択した連絡先ごとの .vcf がひとつのフォルダに入ります。'
+						: 'The .zip contains one folder with one fixed .vcf file per selected contact.'}
 				</p>
 			</section>
 		{/if}

--- a/src/style.css
+++ b/src/style.css
@@ -368,11 +368,11 @@ main {
 .hero {
 	position: relative;
 	min-height: 100vh;
-	padding: 6.25rem var(--pad-inline) 6rem;
+	padding: clamp(6rem, 7vw, 7.25rem) var(--pad-inline) 6rem;
 	display: grid;
-	grid-template-columns: minmax(0, 1.4fr) minmax(18rem, 1fr);
+	grid-template-columns: minmax(0, 1.36fr) minmax(19rem, 0.84fr);
 	grid-template-rows: 1fr auto;
-	gap: 3rem 5rem;
+	gap: 3rem clamp(3rem, 6vw, 5.5rem);
 	max-width: var(--max);
 	margin: 0 auto;
 	overflow: hidden;
@@ -391,8 +391,8 @@ main {
 	position: relative;
 	z-index: 2;
 	align-self: end;
-	padding: 0.75rem 1rem;
-	margin-left: -1rem;
+	padding: 0.75rem 0;
+	margin-left: 0;
 	pointer-events: none;
 	background: radial-gradient(
 		ellipse at 30% 70%,
@@ -410,11 +410,12 @@ main {
 	position: relative;
 	z-index: 2;
 	align-self: end;
+	justify-self: start;
 	display: flex;
 	flex-direction: column;
-	gap: 1.75rem;
-	max-width: 38ch;
-	padding: 1rem 1.125rem;
+	gap: 1.5rem;
+	max-width: 39ch;
+	padding: 0.875rem 0;
 	font-size: 1rem;
 	color: var(--ink-soft);
 	line-height: 1.7;


### PR DESCRIPTION
Updates the personal site positioning around human-centric AI across homepage/about metadata and copy.

Improves the VCF splitter by normalizing contact names, adding missing FN/N fields, preserving one-contact downloads, and packaging selected contacts into a zip folder.

Also adjusts hero layout spacing to fit the refreshed copy.

Validation: `npm run check` and `npm run build` passed; `npm run lint` is blocked by an existing Prettier/Svelte `getVisitorKeys` tooling error.